### PR TITLE
fix: run CI on push to main so the badge stays current

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ name: CI
 # This restriction will be revisited once a clean solution is identified.
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main, dev]
 

--- a/exordium/video/face/gaze/base.py
+++ b/exordium/video/face/gaze/base.py
@@ -510,7 +510,7 @@ class GazeWrapper(ABC):
         if roll_angles is None:
             roll_angles = [0.0] * len(x)
 
-        results: list[np.ndarray] = []
+        results: list[np.ndarray | torch.Tensor] = []
         for i, (y, p, roll) in enumerate(zip(yaw_list, pitch_list, roll_angles)):
             face_np = x[i].permute(1, 2, 0).cpu().numpy()  # (H, W, 3)
             h, w = face_np.shape[:2]

--- a/exordium/video/face/gaze/base.py
+++ b/exordium/video/face/gaze/base.py
@@ -510,7 +510,7 @@ class GazeWrapper(ABC):
         if roll_angles is None:
             roll_angles = [0.0] * len(x)
 
-        results = []
+        results: list[np.ndarray] = []
         for i, (y, p, roll) in enumerate(zip(yaw_list, pitch_list, roll_angles)):
             face_np = x[i].permute(1, 2, 0).cpu().numpy()  # (H, W, 3)
             h, w = face_np.shape[:2]


### PR DESCRIPTION
## Summary

- The CI badge (`workflows/CI/badge.svg`) reflects the last CI run on the **default branch**
- With only a `pull_request` trigger, no CI run ever executes *on* main — the badge shows a stale or failed state
- Adding `push: branches: [main]` ensures a fresh CI run fires on every merge, keeping the badge green

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, a CI run triggers on main and the badge turns green

🤖 Generated with [Claude Code](https://claude.com/claude-code)