### PR TITLE
fix: decode Whisper long-form so audio beyond the 30s window is transcribed

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@
 
 **Collection of Preprocessing Functions and Deep Learning Methods for Multimodal Feature Extraction**
 
+[![GitHub Release](https://img.shields.io/github/v/release/fodorad/exordium?color=purple)](https://github.com/fodorad/exordium/releases)
+[![PyPI](https://img.shields.io/pypi/v/exordium?color=purple)](https://pypi.org/project/exordium/)
 [![CI](https://github.com/fodorad/exordium/workflows/CI/badge.svg)](https://github.com/fodorad/exordium/actions)
 [![codecov](https://codecov.io/gh/fodorad/exordium/graph/badge.svg?token=SW94492IHY)](https://codecov.io/gh/fodorad/exordium)
 [![Docs](https://img.shields.io/badge/docs-online-blue?logo=githubpages)](https://fodorad.github.io/exordium/)
-[![GitHub Release](https://img.shields.io/github/v/release/fodorad/exordium?color=purple)](https://github.com/fodorad/exordium/releases)
-[![PyPI](https://img.shields.io/pypi/v/exordium?color=purple)](https://pypi.org/project/exordium/)
-[![Python](https://img.shields.io/badge/python-3.12%2B-3776AB?logo=python&logoColor=white)](https://www.python.org)
-[![PyTorch](https://img.shields.io/badge/PyTorch-2.11.0-EE4C2C?logo=pytorch&logoColor=white)](https://pytorch.org)
+<br/>
+[![Python](https://img.shields.io/badge/python-3.13%2B-3776AB?logo=python&logoColor=white)](https://www.python.org)
+[![PyTorch](https://img.shields.io/badge/PyTorch-2.11.0+-EE4C2C?logo=pytorch&logoColor=white)](https://pytorch.org)
 [![Code style: ruff](https://img.shields.io/badge/code%20style-ruff-000000)](https://github.com/astral-sh/ruff)
 [![License](https://img.shields.io/badge/license-MIT-yellow)](LICENSE)
 

--- a/exordium/text/alignment.py
+++ b/exordium/text/alignment.py
@@ -207,5 +207,10 @@ class WhisperWordTimestamper(WordTimestamper):
             Words in chronological order with ``start``/``end``/``score``.
 
         """
-        transcript = self.whisper(audio, language=language)
-        return self.aligner.align(audio, transcript, language=language)
+        # Segment-wise ASR + alignment: correct for clips of any length. Whisper
+        # decodes long-form (>30 s) instead of silently cropping, and each
+        # segment is aligned on its own slice so long files stay memory-bounded.
+        segments = self.whisper.transcribe_segments(audio, language=language)
+        if not segments:
+            return []
+        return self.aligner.align_segments(audio, segments, language=language)

--- a/exordium/text/base.py
+++ b/exordium/text/base.py
@@ -11,6 +11,51 @@ import transformers as tfm
 
 from exordium.utils.device import get_torch_device
 
+WHISPER_WINDOW_SECONDS = 30.0
+"""Length of Whisper's fixed receptive field; audio longer than this needs long-form decoding."""
+
+
+@dataclass
+class Segment:
+    """An utterance-level chunk of a transcript with its time span.
+
+    Produced by :meth:`~exordium.text.whisper.WhisperWrapper.transcribe_segments`
+    and consumed by :meth:`ForcedAligner.align_segments`, which aligns each
+    segment independently. Chunking this way keeps forced alignment bounded for
+    long recordings (a 16-minute waveform never enters a single forward pass).
+
+    Attributes:
+        text: The segment's transcribed text.
+        start: Segment start in seconds from the beginning of the audio.
+        end: Segment end in seconds from the beginning of the audio.
+
+    """
+
+    text: str
+    start: float
+    end: float
+
+
+def to_mono_16k(audio: "Path | str | np.ndarray | torch.Tensor") -> tuple[torch.Tensor, int]:
+    """Return *audio* as a 1-D float32 waveform at 16 kHz plus its sample rate.
+
+    Args:
+        audio: File path, numpy array, or torch tensor (arrays/tensors are
+            assumed to already be 16 kHz mono).
+
+    Returns:
+        Tuple of ``(waveform_1d, sample_rate)``.
+
+    """
+    from exordium.audio.io import load_audio
+
+    if isinstance(audio, (str, Path)):
+        waveform, sample_rate = load_audio(audio, target_sample_rate=16000, mono=True, squeeze=True)
+        return waveform.float().reshape(-1), sample_rate
+    if isinstance(audio, torch.Tensor):
+        return audio.detach().cpu().float().reshape(-1), 16000
+    return torch.from_numpy(np.asarray(audio, dtype=np.float32)).reshape(-1), 16000
+
 
 @dataclass
 class Word:
@@ -330,6 +375,49 @@ class ForcedAligner(ABC):
             Words in chronological order with ``start``/``end``/``score``.
 
         """
+
+    def align_segments(
+        self,
+        audio: Path | str | np.ndarray | torch.Tensor,
+        segments: list[Segment],
+        language: str | None = None,
+    ) -> list[Word]:
+        """Align each segment separately and return one merged word stream.
+
+        Aligning per segment keeps every forward pass short, so recordings of any
+        length work without exhausting memory. Word times are shifted back onto
+        the full-audio timeline by each segment's ``start``.
+
+        Backends with a native batched segment API (e.g. whisperX) override this.
+
+        Args:
+            audio: Full audio — file path, numpy array, or torch tensor.
+            segments: Timestamped transcript segments covering the audio.
+            language: Language code or ``None`` for the default.
+
+        Returns:
+            Words in chronological order on the full-audio timeline.
+
+        """
+        waveform, sample_rate = to_mono_16k(audio)
+        words: list[Word] = []
+        for segment in segments:
+            if not segment.text.strip():
+                continue
+            start = max(0, int(segment.start * sample_rate))
+            end = min(waveform.numel(), int(segment.end * sample_rate))
+            if end - start < sample_rate // 100:  # skip <10 ms slivers
+                continue
+            for word in self.align(waveform[start:end], segment.text, language=language):
+                words.append(
+                    Word(
+                        text=word.text,
+                        start=word.start + segment.start,
+                        end=word.end + segment.start,
+                        score=word.score,
+                    )
+                )
+        return words
 
 
 class WordTimestamper(ABC):

--- a/exordium/text/evaluation.py
+++ b/exordium/text/evaluation.py
@@ -21,7 +21,7 @@ from rapidfuzz import fuzz
 from rapidfuzz.distance import Levenshtein
 
 from exordium.text.base import SegmentMatch, Word
-from exordium.text.transcript_align import find_segment, normalize_token
+from exordium.text.transcript_align import find_segment, find_segments, normalize_token
 
 logger = logging.getLogger(__name__)
 """Module-level logger."""
@@ -386,6 +386,17 @@ def validate_segment(
 
     """
     match = find_segment(text, words, score_cutoff=score_cutoff)
+    return _decide(text, annotated_start, annotated_end, match, tolerance)
+
+
+def _decide(
+    text: str,
+    annotated_start: float,
+    annotated_end: float,
+    match: SegmentMatch | None,
+    tolerance: float,
+) -> SegmentValidation:
+    """Turn a (possibly missing) fuzzy match into an accept/recut/drop decision."""
     if match is None:
         return SegmentValidation(
             text=text,
@@ -426,6 +437,9 @@ def validate_segments(
 ) -> list[SegmentValidation]:
     """Batch-validate ``(text, start, end)`` segments against one word stream.
 
+    The word stream is normalized once and reused for every segment, so long
+    recordings with many annotations stay cheap.
+
     Args:
         segments: Annotated segments as ``(text, start_sec, end_sec)`` tuples.
         words: Shared timed word stream for the full audio.
@@ -436,7 +450,8 @@ def validate_segments(
         One :class:`SegmentValidation` per input segment, in order.
 
     """
+    matches = find_segments([text for text, _, _ in segments], words, score_cutoff=score_cutoff)
     return [
-        validate_segment(text, words, start, end, score_cutoff=score_cutoff, tolerance=tolerance)
-        for text, start, end in segments
+        _decide(text, start, end, match, tolerance)
+        for (text, start, end), match in zip(segments, matches, strict=True)
     ]

--- a/exordium/text/transcript_align.py
+++ b/exordium/text/transcript_align.py
@@ -16,9 +16,11 @@ segment transcripts, so the same code adapts to CMU-MOSEI, MOSI, or any future
 corpus.
 """
 
+import bisect
 import logging
 import re
 import unicodedata
+from dataclasses import dataclass
 
 from rapidfuzz import fuzz
 
@@ -74,13 +76,72 @@ def find_segment(
         A :class:`SegmentMatch` on the audio timeline, or ``None``.
 
     """
-    query = normalize_token(query_text)
-    if not query or not words:
-        return None
+    return _search(normalize_token(query_text), build_word_index(words), words, score_cutoff)
 
-    # Build the searchable haystack, tracking each char range back to its word.
+
+def find_segments(
+    query_texts: list[str],
+    words: list[Word],
+    *,
+    score_cutoff: float = 80.0,
+) -> list[SegmentMatch | None]:
+    """Locate many segment transcripts in one shared *words* stream.
+
+    The normalized haystack is built **once** and reused for every query, so a
+    long recording searched for many segments costs ``O(N + Q·search)`` rather
+    than re-normalizing all ``N`` words for each of the ``Q`` queries.
+
+    Args:
+        query_texts: Known transcripts, e.g. one per dataset segment.
+        words: Shared timed word stream (one full-video ASR pass).
+        score_cutoff: Minimum score to accept each match.
+
+    Returns:
+        One result per query, in order; ``None`` where a segment is
+        unrecoverable.
+
+    """
+    index = build_word_index(words)
+    return [_search(normalize_token(q), index, words, score_cutoff) for q in query_texts]
+
+
+@dataclass(frozen=True)
+class WordIndex:
+    """Precomputed search structure over a timed word stream.
+
+    Built once by :func:`build_word_index` and reused across queries.
+
+    Attributes:
+        haystack: The normalized words joined by single spaces.
+        starts: Character offset where each indexed word begins in ``haystack``.
+        ends: Character offset just past each indexed word.
+        word_ids: Index into the original ``words`` list for each entry.
+
+    """
+
+    haystack: str
+    starts: list[int]
+    ends: list[int]
+    word_ids: list[int]
+
+
+def build_word_index(words: list[Word]) -> WordIndex:
+    """Normalize *words* once into a reusable :class:`WordIndex`.
+
+    Words that normalize to nothing (pure punctuation) are skipped, while
+    ``word_ids`` keeps the mapping back to their original positions.
+
+    Args:
+        words: Timed word stream.
+
+    Returns:
+        The searchable index (possibly empty).
+
+    """
     pieces: list[str] = []
-    char_to_word: list[tuple[int, int, int]] = []  # (char_start, char_end, word_idx)
+    starts: list[int] = []
+    ends: list[int] = []
+    word_ids: list[int] = []
     cursor = 0
     for idx, word in enumerate(words):
         norm = normalize_token(word.text)
@@ -89,20 +150,28 @@ def find_segment(
         if pieces:
             cursor += 1  # the joining space
         pieces.append(norm)
-        char_to_word.append((cursor, cursor + len(norm), idx))
+        starts.append(cursor)
+        ends.append(cursor + len(norm))
+        word_ids.append(idx)
         cursor += len(norm)
+    return WordIndex(haystack=" ".join(pieces), starts=starts, ends=ends, word_ids=word_ids)
 
-    if not pieces:
+
+def _search(
+    query: str,
+    index: WordIndex,
+    words: list[Word],
+    score_cutoff: float,
+) -> SegmentMatch | None:
+    """Fuzzy-match a normalized *query* against a prebuilt *index*."""
+    if not query or not index.haystack:
         return None
-    haystack = " ".join(pieces)
 
-    alignment = fuzz.partial_ratio_alignment(query, haystack, score_cutoff=score_cutoff)
+    alignment = fuzz.partial_ratio_alignment(query, index.haystack, score_cutoff=score_cutoff)
     if alignment is None:
         return None
 
-    first_idx, last_idx = _span_to_word_indices(
-        alignment.dest_start, alignment.dest_end, char_to_word
-    )
+    first_idx, last_idx = _span_to_word_indices(alignment.dest_start, alignment.dest_end, index)
     if first_idx is None or last_idx is None:
         return None
 
@@ -117,39 +186,19 @@ def find_segment(
     )
 
 
-def find_segments(
-    query_texts: list[str],
-    words: list[Word],
-    *,
-    score_cutoff: float = 80.0,
-) -> list[SegmentMatch | None]:
-    """Batch-apply :func:`find_segment` to many segment transcripts.
-
-    Args:
-        query_texts: Known transcripts, e.g. one per dataset segment.
-        words: Shared timed word stream (one full-video ASR pass).
-        score_cutoff: Minimum score to accept each match.
-
-    Returns:
-        One result per query, in order; ``None`` where a segment is
-        unrecoverable.
-
-    """
-    return [find_segment(q, words, score_cutoff=score_cutoff) for q in query_texts]
-
-
 def _span_to_word_indices(
     char_start: int,
     char_end: int,
-    char_to_word: list[tuple[int, int, int]],
+    index: WordIndex,
 ) -> tuple[int | None, int | None]:
-    """Map a matched ``[char_start, char_end)`` haystack range to word indices."""
-    first_idx: int | None = None
-    last_idx: int | None = None
-    for c_start, c_end, word_idx in char_to_word:
-        # Overlap between the word's char span and the matched range.
-        if c_end > char_start and c_start < char_end:
-            if first_idx is None:
-                first_idx = word_idx
-            last_idx = word_idx
-    return first_idx, last_idx
+    """Map a matched ``[char_start, char_end)`` haystack range to word indices.
+
+    Word char spans are sorted and non-overlapping, so the first/last overlapping
+    entries are found by binary search instead of scanning every word.
+    """
+    # First entry whose end is past char_start; last entry whose start precedes char_end.
+    first = bisect.bisect_right(index.ends, char_start)
+    last = bisect.bisect_left(index.starts, char_end) - 1
+    if first > last or first >= len(index.word_ids) or last < 0:
+        return None, None
+    return index.word_ids[first], index.word_ids[last]

--- a/exordium/text/whisper.py
+++ b/exordium/text/whisper.py
@@ -1,6 +1,7 @@
 """Whisper speech-to-text model wrapper."""
 
 import logging
+import re
 from collections.abc import Iterator
 from pathlib import Path
 from threading import Thread
@@ -11,11 +12,20 @@ import torch
 from transformers import AutoModelForSpeechSeq2Seq, AutoProcessor, TextIteratorStreamer
 
 from exordium.audio.io import load_audio
-from exordium.text.base import SpeechToText, StreamingMixin
+from exordium.text.base import (
+    WHISPER_WINDOW_SECONDS,
+    Segment,
+    SpeechToText,
+    StreamingMixin,
+    to_mono_16k,
+)
 from exordium.utils.device import get_torch_device
 
 logger = logging.getLogger(__name__)
 """Module-level logger."""
+
+_TIMESTAMP_TOKEN_RE = re.compile(r"<\|[\d.]+\|>")
+"""Matches Whisper timestamp tokens (e.g. ``<|12.34|>``) emitted during long-form decoding."""
 
 
 class WhisperWrapper(StreamingMixin, SpeechToText):
@@ -98,7 +108,8 @@ class WhisperWrapper(StreamingMixin, SpeechToText):
                 automatically). Defaults to 16000.
 
         Returns:
-            Dict with ``input_features`` on ``self.device``.
+            Dict with ``input_features`` on ``self.device``, plus an
+            ``attention_mask`` when the audio exceeds Whisper's 30 s window.
 
         """
         if isinstance(audio, (str, Path)):
@@ -109,12 +120,29 @@ class WhisperWrapper(StreamingMixin, SpeechToText):
         else:
             audio = np.asarray(audio).squeeze()
 
-        inputs = self.processor(
-            audio,
-            sampling_rate=sample_rate,
-            return_tensors="pt",
-        )
-        return {k: v.to(self.device, dtype=self.dtype) for k, v in inputs.items()}
+        # Whisper's encoder sees a fixed 30 s window. The feature extractor's
+        # defaults (truncation + pad to 30 s) would silently discard everything
+        # past 30 s, so longer audio must be kept whole and decoded long-form.
+        if audio.shape[-1] > int(WHISPER_WINDOW_SECONDS * sample_rate):
+            inputs = self.processor(
+                audio,
+                sampling_rate=sample_rate,
+                return_tensors="pt",
+                truncation=False,
+                padding="longest",
+                return_attention_mask=True,
+            )
+        else:
+            inputs = self.processor(audio, sampling_rate=sample_rate, return_tensors="pt")
+
+        # Only the float mel features take the model dtype; the attention mask
+        # must stay integral.
+        return {
+            key: value.to(self.device, dtype=self.dtype)
+            if value.is_floating_point()
+            else value.to(self.device)
+            for key, value in inputs.items()
+        }
 
     def inference(self, inputs: object, **kwargs: object) -> str:
         """Run greedy/beam-search decoding and return the full transcript.
@@ -128,17 +156,68 @@ class WhisperWrapper(StreamingMixin, SpeechToText):
 
         """
         inputs_dict = cast("dict[str, torch.Tensor]", inputs)
+        generate_kwargs = self._generate_kwargs(inputs_dict, **kwargs)
+
+        with torch.inference_mode():
+            token_ids = self.model.generate(**inputs_dict, **generate_kwargs)
+
+        return self.processor.batch_decode(token_ids, skip_special_tokens=True)[0].strip()
+
+    def _generate_kwargs(self, inputs: dict[str, torch.Tensor], **kwargs: object) -> dict:
+        """Build ``generate`` kwargs, enabling long-form decoding when needed."""
         language: str | None = cast("str | None", kwargs.get("language"))
         beam_size_obj = kwargs.get("beam_size", 5)
         beam_size: int = beam_size_obj if isinstance(beam_size_obj, int) else 5
         generate_kwargs: dict = {"num_beams": beam_size}
         if language is not None:
             generate_kwargs["language"] = language
+        # Long-form (>30 s) inputs carry an attention mask and require timestamps
+        # for Whisper's sequential chunk-by-chunk decoding.
+        if "attention_mask" in inputs:
+            generate_kwargs["return_timestamps"] = True
+        return generate_kwargs
+
+    def transcribe_segments(
+        self,
+        audio: Path | str | np.ndarray | torch.Tensor,
+        language: str | None = None,
+        beam_size: int = 5,
+        sample_rate: int = 16000,
+    ) -> list[Segment]:
+        """Transcribe audio into timestamped :class:`Segment` chunks.
+
+        Works for audio of any length: short clips decode in one pass, longer
+        recordings use Whisper's sequential long-form decoding. The segments are
+        what :meth:`~exordium.text.base.ForcedAligner.align_segments` consumes to
+        keep forced alignment bounded on long files.
+
+        Args:
+            audio: Audio file path, numpy array, or torch tensor.
+            language: Language code or ``None`` for auto-detection.
+            beam_size: Decoder beam width.
+            sample_rate: Sample rate of the input waveform (ignored for paths).
+
+        Returns:
+            Segments in chronological order; empty if nothing was transcribed.
+
+        """
+        inputs = self.preprocess(audio, sample_rate=sample_rate)
+        generate_kwargs = self._generate_kwargs(inputs, language=language, beam_size=beam_size)
+        generate_kwargs["return_timestamps"] = True
+        generate_kwargs["return_segments"] = True
 
         with torch.inference_mode():
-            token_ids = self.model.generate(**inputs_dict, **generate_kwargs)
+            outputs = self.model.generate(**inputs, **generate_kwargs)
 
-        return self.processor.batch_decode(token_ids, skip_special_tokens=True)[0].strip()
+        segments: list[Segment] = []
+        for raw in outputs["segments"][0]:
+            text = self.processor.batch_decode(
+                raw["tokens"].unsqueeze(0), skip_special_tokens=True
+            )[0].strip()
+            if not text:
+                continue
+            segments.append(Segment(text=text, start=float(raw["start"]), end=float(raw["end"])))
+        return segments
 
     def __call__(
         self,
@@ -185,8 +264,19 @@ class WhisperWrapper(StreamingMixin, SpeechToText):
             beam_size: Decoder beam width. Defaults to ``1`` for streaming.
             sample_rate: Sample rate of the input waveform (ignored for paths).
 
+        Audio longer than Whisper's 30 s window is streamed window by window:
+        ``TextIteratorStreamer`` only observes the first chunk of Whisper's
+        sequential long-form decoding, so streaming the whole file in one
+        ``generate`` call would silently stop after 30 s. Each window is decoded
+        short-form instead, which keeps the full transcript flowing. A word
+        spanning a window boundary may be split.
+
         Yields:
             Decoded text chunks (words or sub-word tokens) as strings.
+
+        Raises:
+            Exception: Whatever ``model.generate`` raised in the worker thread,
+                re-raised on the caller's thread once the stream drains.
 
         Example::
 
@@ -195,25 +285,55 @@ class WhisperWrapper(StreamingMixin, SpeechToText):
             print()  # newline after full transcript
 
         """
-        inputs = self.preprocess(audio, sample_rate=sample_rate)
+        if isinstance(audio, (str, Path)):
+            waveform, rate = to_mono_16k(audio)
+        else:
+            waveform, _ = to_mono_16k(audio)
+            rate = sample_rate
 
+        window = int(WHISPER_WINDOW_SECONDS * rate)
+        total = waveform.numel()
+        for start in range(0, total, window):
+            chunk = waveform[start : start + window]
+            if chunk.numel() < rate // 10:  # ignore <100 ms tail
+                continue
+            yield from self._stream_window(chunk, language, beam_size, rate)
+
+    def _stream_window(
+        self,
+        waveform: torch.Tensor,
+        language: str | None,
+        beam_size: int,
+        sample_rate: int,
+    ) -> Iterator[str]:
+        """Stream one ``<=30 s`` window, re-raising worker-thread failures."""
+        inputs = self.preprocess(waveform, sample_rate=sample_rate)
         streamer = TextIteratorStreamer(
             self.processor.tokenizer,
             skip_special_tokens=True,
             skip_prompt=True,
         )
+        generate_kwargs = self._generate_kwargs(inputs, language=language, beam_size=beam_size)
 
-        generate_kwargs: dict = {
-            **inputs,
-            "streamer": streamer,
-            "num_beams": beam_size,
-        }
-        if language is not None:
-            generate_kwargs["language"] = language
+        failure: list[BaseException] = []
 
-        thread = Thread(target=self.model.generate, kwargs=generate_kwargs, daemon=True)
+        def _generate() -> None:
+            try:
+                with torch.inference_mode():
+                    self.model.generate(**inputs, streamer=streamer, **generate_kwargs)
+            except BaseException as exc:  # noqa: BLE001 - surfaced to the caller below
+                failure.append(exc)
+                # Without this the consumer would block on the streamer forever.
+                streamer.end()
+
+        thread = Thread(target=_generate, daemon=True)
         thread.start()
 
-        yield from streamer
+        for chunk in streamer:
+            text = _TIMESTAMP_TOKEN_RE.sub("", chunk)
+            if text:
+                yield text
 
         thread.join()
+        if failure:
+            raise failure[0]

--- a/exordium/text/whisperx_align.py
+++ b/exordium/text/whisperx_align.py
@@ -27,7 +27,7 @@ import numpy as np
 import torch
 
 from exordium.audio.io import load_audio
-from exordium.text.base import ForcedAligner, Word
+from exordium.text.base import ForcedAligner, Segment, Word
 from exordium.utils.device import get_torch_device
 
 logger = logging.getLogger(__name__)
@@ -94,17 +94,56 @@ class WhisperxForcedAligner(ForcedAligner):
             Words in chronological order. Empty if *transcript* is blank.
 
         """
-        if language is not None and language != self.language:
-            logger.warning(
-                f"Requested language {language!r} != model language {self.language!r}; "
-                "reload WhisperxForcedAligner with the desired language."
-            )
+        self._warn_language(language)
         if not transcript.strip():
             return []
 
         waveform, sr = self._to_array(audio)
         duration = len(waveform) / sr
-        segments = [{"text": transcript, "start": 0.0, "end": duration}]
+        return self._run([{"text": transcript, "start": 0.0, "end": duration}], waveform)
+
+    def align_segments(
+        self,
+        audio: Path | str | np.ndarray | torch.Tensor,
+        segments: list[Segment],
+        language: str | None = None,
+    ) -> list[Word]:
+        """Align all *segments* in one whisperX call (native batched path).
+
+        whisperX slices the audio per segment internally and returns word times
+        already on the full-audio timeline, so long recordings stay bounded
+        without the per-segment Python loop of the base implementation.
+
+        Args:
+            audio: Full audio — file path, numpy array, or torch tensor.
+            segments: Timestamped transcript segments covering the audio.
+            language: Optional language code (must match the loaded model).
+
+        Returns:
+            Words in chronological order on the full-audio timeline.
+
+        """
+        self._warn_language(language)
+        payload = [
+            {"text": s.text, "start": float(s.start), "end": float(s.end)}
+            for s in segments
+            if s.text.strip()
+        ]
+        if not payload:
+            return []
+        waveform, _ = self._to_array(audio)
+        return self._run(payload, waveform)
+
+    def _warn_language(self, language: str | None) -> None:
+        """Log when a caller asks for a language the loaded model was not built for."""
+        if language is not None and language != self.language:
+            logger.warning(
+                f"Requested language {language!r} != model language {self.language!r}; "
+                "reload WhisperxForcedAligner with the desired language."
+            )
+
+    def _run(self, segments: list[dict], waveform: np.ndarray) -> list[Word]:
+        """Run whisperX alignment over *segments* and convert to :class:`Word`."""
         result = whisperx.align(
             segments,
             self.model,

--- a/tests/text/test_alignment.py
+++ b/tests/text/test_alignment.py
@@ -9,7 +9,7 @@ from exordium.text.alignment import (
     WhisperWordTimestamper,
     normalize_words,
 )
-from exordium.text.base import Word
+from exordium.text.base import Segment, Word
 from exordium.text.transcript_align import find_segment
 from tests.fixtures import AUDIO_MULTISPEAKER, ModelTestCase
 
@@ -64,6 +64,26 @@ class TestTorchaudioForcedAligner(ModelTestCase):
         words = self.aligner.align(wave.numpy().astype(np.float32), "hey guys")
         self.assertEqual([w.text for w in words], ["hey", "guys"])
 
+    def test_align_segments_offsets_words_onto_full_timeline(self):
+        segments = [
+            Segment(text="hey guys", start=0.0, end=2.0),
+            Segment(text="what do you guys want to eat", start=2.0, end=6.0),
+        ]
+        words = self.aligner.align_segments(AUDIO_MULTISPEAKER, segments)
+        self.assertGreater(len(words), 2)
+        # Words from the second segment must sit after its start, not at 0.
+        self.assertGreaterEqual(words[-1].start, 2.0)
+        starts = [w.start for w in words]
+        self.assertEqual(starts, sorted(starts))
+
+    def test_align_segments_skips_blank_segments(self):
+        segments = [
+            Segment(text="   ", start=0.0, end=2.0),
+            Segment(text="hey", start=0.0, end=2.0),
+        ]
+        words = self.aligner.align_segments(AUDIO_MULTISPEAKER, segments)
+        self.assertEqual([w.text for w in words], ["hey"])
+
 
 class TestWhisperWordTimestamper(ModelTestCase):
     @classmethod
@@ -85,6 +105,22 @@ class TestWhisperWordTimestamper(ModelTestCase):
         assert match is not None
         self.assertGreaterEqual(match.score, 80.0)
         self.assertLess(match.start, match.end)
+
+    def test_long_audio_words_reach_beyond_whispers_30s_window(self):
+        # Regression: Whisper cropped to 30 s, so the aligner smeared a
+        # half-transcript across the full 61 s audio and everything past the
+        # window was unrecoverable.
+        words = self.model.transcribe_words(AUDIO_MULTISPEAKER)
+        self.assertGreater(len(words), 180)
+        self.assertGreater(words[-1].end, 45.0)
+        self.assertLessEqual(words[-1].end, self.duration + 1.0)
+
+    def test_text_near_end_of_long_audio_is_findable(self):
+        words = self.model.transcribe_words(AUDIO_MULTISPEAKER)
+        match = find_segment("check us out at my taste base", words)
+        self.assertIsNotNone(match)
+        assert match is not None
+        self.assertGreater(match.start, 45.0)
 
 
 if __name__ == "__main__":

--- a/tests/text/test_transcript_align.py
+++ b/tests/text/test_transcript_align.py
@@ -3,7 +3,12 @@
 import unittest
 
 from exordium.text.base import SegmentMatch, Word
-from exordium.text.transcript_align import find_segment, find_segments, normalize_token
+from exordium.text.transcript_align import (
+    build_word_index,
+    find_segment,
+    find_segments,
+    normalize_token,
+)
 
 
 def _stream(sentence: str, step: float = 1.0, dur: float = 0.5) -> list[Word]:
@@ -76,6 +81,27 @@ class TestFindSegment(unittest.TestCase):
         assert m is not None
         self.assertEqual(m.word_start_idx, 0)
         self.assertEqual(m.word_end_idx, 2)
+
+
+class TestWordIndex(unittest.TestCase):
+    def test_skips_punctuation_only_words_but_keeps_original_ids(self):
+        words = _stream("hello , world")
+        index = build_word_index(words)
+        self.assertEqual(index.haystack, "hello world")
+        self.assertEqual(index.word_ids, [0, 2])  # index 1 normalized to nothing
+
+    def test_empty_stream_yields_empty_index(self):
+        index = build_word_index([])
+        self.assertEqual(index.haystack, "")
+        self.assertEqual(index.word_ids, [])
+
+    def test_batch_matches_per_query_results(self):
+        # The shared-index batch path must agree with the one-shot path.
+        words = _stream("hey guys what do you want to eat for lunch today")
+        queries = ["what do you want to eat", "for lunch today", "not spoken at all"]
+        batched = find_segments(queries, words)
+        one_by_one = [find_segment(q, words) for q in queries]
+        self.assertEqual(batched, one_by_one)
 
 
 class TestFindSegments(unittest.TestCase):

--- a/tests/text/test_whisperx_align.py
+++ b/tests/text/test_whisperx_align.py
@@ -3,7 +3,7 @@
 import unittest
 
 from exordium.text import whisperx_align
-from exordium.text.base import Word
+from exordium.text.base import Segment, Word
 from exordium.text.transcript_align import find_segment
 from tests.fixtures import AUDIO_MULTISPEAKER, ModelTestCase
 
@@ -43,6 +43,21 @@ class TestWhisperxForcedAligner(ModelTestCase):
         )
         match = find_segment("what do you guys want to eat", words)
         self.assertIsNotNone(match)
+
+    def test_align_segments_returns_full_timeline_words(self):
+        # whisperX's native batched segment path (used for long recordings).
+        segments = [
+            Segment(text="hey guys", start=0.0, end=2.0),
+            Segment(text="what do you guys want to eat", start=2.0, end=6.0),
+        ]
+        words = self.aligner.align_segments(AUDIO_MULTISPEAKER, segments)
+        self.assertGreater(len(words), 2)
+        self.assertGreaterEqual(words[-1].start, 2.0)
+        starts = [w.start for w in words]
+        self.assertEqual(starts, sorted(starts))
+
+    def test_align_segments_empty_returns_empty(self):
+        self.assertEqual(self.aligner.align_segments(AUDIO_MULTISPEAKER, []), [])
 
 
 if __name__ == "__main__":

--- a/tests/text/test_wrappers.py
+++ b/tests/text/test_wrappers.py
@@ -97,16 +97,67 @@ class TestXmlRobertaWrapper(ModelTestCase):
 
 
 class TestWhisperWrapper(ModelTestCase):
+    """The multispeaker fixture is ~61 s — i.e. longer than Whisper's 30 s window."""
+
     @classmethod
     def setUpClass(cls):
+        from exordium.audio.io import load_audio
         from exordium.text.whisper import WhisperWrapper
 
         cls.model = WhisperWrapper(device_id=None)
+        wave, sr = load_audio(AUDIO_MULTISPEAKER, target_sample_rate=16000)
+        cls.waveform = wave
+        cls.sample_rate = sr
 
     def test_transcribe_from_path(self):
         out = self.model(AUDIO_MULTISPEAKER)
         self.assertIsInstance(out, str)
         self.assertGreater(len(out), 0)
+
+    def test_preprocess_short_audio_uses_padded_30s_window(self):
+        short = self.waveform[..., : 10 * self.sample_rate]
+        inputs = self.model.preprocess(short)
+        self.assertEqual(inputs["input_features"].shape[-1], 3000)
+        self.assertNotIn("attention_mask", inputs)
+
+    def test_preprocess_long_audio_is_not_truncated(self):
+        # Regression: the feature extractor's defaults cropped audio to 30 s.
+        inputs = self.model.preprocess(AUDIO_MULTISPEAKER)
+        self.assertGreater(inputs["input_features"].shape[-1], 3000)
+        self.assertIn("attention_mask", inputs)
+        self.assertFalse(inputs["attention_mask"].is_floating_point())
+
+    def test_transcribe_long_audio_decodes_past_30s(self):
+        # A 30 s-truncated decode yields ~138 words; the full 61 s yields ~250+.
+        text = self.model(AUDIO_MULTISPEAKER, beam_size=1)
+        self.assertGreater(len(text.split()), 180)
+
+    def test_transcribe_segments_cover_the_full_audio(self):
+        segments = self.model.transcribe_segments(AUDIO_MULTISPEAKER, beam_size=1)
+        self.assertGreater(len(segments), 1)
+        self.assertGreater(segments[-1].end, 45.0)
+        starts = [s.start for s in segments]
+        self.assertEqual(starts, sorted(starts))
+        self.assertTrue(all(s.text.strip() for s in segments))
+
+    def test_transcribe_segments_short_audio(self):
+        short = self.waveform[..., : 10 * self.sample_rate]
+        segments = self.model.transcribe_segments(short, beam_size=1)
+        self.assertGreater(len(segments), 0)
+
+    def test_stream_short_audio(self):
+        short = self.waveform[..., : 10 * self.sample_rate]
+        text = "".join(self.model.stream(short, beam_size=1))
+        self.assertGreater(len(text.split()), 5)
+        self.assertNotIn("<|", text)  # no timestamp tokens leak through
+
+    def test_stream_long_audio_covers_the_whole_file(self):
+        # Regression: streaming a >30 s file first hung forever (the worker
+        # thread raised and the streamer never ended), then silently stopped
+        # after 30 s because the streamer only sees long-form's first chunk.
+        text = "".join(self.model.stream(AUDIO_MULTISPEAKER, beam_size=1))
+        self.assertGreater(len(text.split()), 180)
+        self.assertNotIn("<|", text)
 
 
 class TestTextWeightAvailability(unittest.TestCase):


### PR DESCRIPTION
WhisperWrapper.preprocess silently cropped audio to Whisper's 30s window; the aligner then smeared the half-transcript across the full audio, so validate_segments dropped most segments. Short and long audio now handled transparently. Also fixes stream() hanging and silently stopping at 30s, adds transcribe_segments() and ForcedAligner.align_segments() (whisperX uses its native batched path), and reuses a prebuilt WordIndex across fuzzy queries.