### PR TITLE
fix(text): widen degenerate segments instead of crashing forced alignment

### DIFF
--- a/exordium/text/alignment.py
+++ b/exordium/text/alignment.py
@@ -24,7 +24,13 @@ import torch
 import torchaudio
 
 from exordium.audio.io import load_audio
-from exordium.text.base import ForcedAligner, Word, WordTimestamper
+from exordium.text.base import (
+    MIN_ALIGN_SAMPLES,
+    ForcedAligner,
+    Word,
+    WordTimestamper,
+    wav2vec2_min_samples,
+)
 from exordium.utils.device import get_torch_device
 
 if TYPE_CHECKING:
@@ -87,6 +93,26 @@ class TorchaudioForcedAligner(ForcedAligner):
         self.tokenizer = bundle.get_tokenizer()
         self.aligner = bundle.get_aligner()
 
+    def min_align_samples(self, text: str) -> int:
+        """Samples ``MMS_FA`` needs to align *text*, counted with its own tokenizer.
+
+        Overrides the base class's character estimate: ``normalize_words`` strips
+        everything outside the ``MMS_FA`` alphabet, so counting raw characters would
+        demand more audio than the model actually needs.
+
+        Args:
+            text: The text to be aligned.
+
+        Returns:
+            Minimum slice length in samples.
+
+        """
+        words = normalize_words(text)
+        if not words:
+            return MIN_ALIGN_SAMPLES
+        tokens = cast("list[list[int]]", self.tokenizer(words))
+        return wav2vec2_min_samples(sum(len(word_tokens) for word_tokens in tokens))
+
     def align(
         self,
         audio: Path | str | np.ndarray | torch.Tensor,
@@ -102,8 +128,11 @@ class TorchaudioForcedAligner(ForcedAligner):
                 interface compatibility with :class:`ForcedAligner`.
 
         Returns:
-            Words in chronological order. Empty if *transcript* has no
-            alignable tokens.
+            Words in chronological order. Empty if *transcript* has no alignable
+            tokens, or if the audio is too short to carry them — see
+            :func:`~exordium.text.base.wav2vec2_min_samples`.  Callers aligning
+            whole recordings should go through :meth:`align_segments`, which
+            widens short windows instead of giving up on them.
 
         """
         del language  # MMS_FA is a single multilingual model.
@@ -111,6 +140,16 @@ class TorchaudioForcedAligner(ForcedAligner):
         words = normalize_words(transcript)
         if not words:
             logger.warning("Transcript has no alignable tokens; returning [].")
+            return []
+
+        num_samples = waveform.size(1)
+        needed = self.min_align_samples(transcript)
+        if num_samples < needed:
+            # Too few frames for the tokens: MMS_FA's conv stack or forced_align raises.
+            logger.warning(
+                f"Audio is {num_samples} samples but {' '.join(words)!r} needs {needed} "
+                "to force-align; returning []."
+            )
             return []
 
         with torch.inference_mode():

--- a/exordium/text/base.py
+++ b/exordium/text/base.py
@@ -1,7 +1,8 @@
 """Abstract base classes for text and speech-to-text models."""
 
+import logging
 from abc import ABC, abstractmethod
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -11,8 +12,68 @@ import transformers as tfm
 
 from exordium.utils.device import get_torch_device
 
+logger = logging.getLogger(__name__)
+"""Module-level logger."""
+
 WHISPER_WINDOW_SECONDS = 30.0
 """Length of Whisper's fixed receptive field; audio longer than this needs long-form decoding."""
+
+WAV2VEC2_RECEPTIVE_FIELD_SAMPLES = 400
+"""Samples consumed by one wav2vec2 emission frame (the conv frontend's receptive field)."""
+
+WAV2VEC2_STRIDE_SAMPLES = 320
+"""Samples between consecutive wav2vec2 emission frames (the conv frontend's total stride)."""
+
+MIN_ALIGN_SAMPLES = WAV2VEC2_RECEPTIVE_FIELD_SAMPLES + WAV2VEC2_STRIDE_SAMPLES
+"""Shortest slice (720 samples, 45 ms @ 16 kHz) that yields **two** emission frames.
+
+One frame is never enough: whisperX rescales its timestamps by
+``duration / (trellis.size(0) - 1)``, so a one-row trellis divides by zero
+(``ZeroDivisionError``) and aborts the whole recording, and ``MMS_FA`` cannot even run
+its conv stack below 400 samples (``RuntimeError``).  This is the floor for *any* text;
+:func:`wav2vec2_min_samples` gives the real, text-dependent requirement.
+"""
+
+
+WIDEN_WINDOW_SECONDS = 0.5
+"""Window a degenerate segment is widened to, over and above the geometric minimum.
+
+:func:`wav2vec2_min_samples` says what the *model* needs; it says nothing about what the
+*speech* needs.  A 4-token word like ``"that"`` needs only 85 ms of frames, but takes
+~250 ms to say, so widening to the geometric floor alone hands CTC a window that clips
+the word — it aligns, but the timestamp comes back truncated (measured: ``"hey"`` scored
+0.02 and returned a 65 ms span against a true 320 ms, starting 137 ms late).
+
+Half a second gives the word room to sit inside the window; measured start error against
+ground truth drops to ~20 ms (about one emission frame).  Wider windows start to drift,
+as the aligner has more audio in which to mistake a similar-sounding neighbour for the
+word it is looking for.
+"""
+
+
+def wav2vec2_min_samples(num_tokens: int) -> int:
+    """Samples needed to force-align *num_tokens* tokens with a wav2vec2 CTC model.
+
+    The conv frontend turns ``N`` samples into ``floor((N - 400) / 320) + 1`` emission
+    frames, and CTC cannot emit more tokens than it has frames.  Aligning ``T`` tokens
+    therefore needs ``T`` frames, i.e. ``N >= 400 + 320 * (T - 1)`` — never fewer than
+    :data:`MIN_ALIGN_SAMPLES`, since a lone frame breaks both backends outright.
+
+    This is why a *constant* minimum is the wrong shape: ``"I"`` needs 720 samples but
+    ``"that"`` needs 1360.  Starving a segment of frames does not merely lose precision —
+    ``MMS_FA`` raises, and whisperX's backtrack fails and returns the words untimed,
+    which drops them silently.
+
+    Args:
+        num_tokens: Number of CTC tokens (characters, for these models) to align.
+
+    Returns:
+        Minimum slice length in samples.
+
+    """
+    tokens = max(1, num_tokens)
+    span = WAV2VEC2_RECEPTIVE_FIELD_SAMPLES + WAV2VEC2_STRIDE_SAMPLES * (tokens - 1)
+    return max(MIN_ALIGN_SAMPLES, span)
 
 
 @dataclass
@@ -34,6 +95,147 @@ class Segment:
     text: str
     start: float
     end: float
+
+
+def _widen(start: int, end: int, target: int, limit: int | None) -> tuple[int, int]:
+    """Grow a ``[start, end)`` sample window to *target* samples around its midpoint.
+
+    Slides the window back inside ``[0, limit)`` if centring would overshoot either edge,
+    so the result is always ``target`` samples long (the caller guarantees the audio is
+    long enough).
+
+    Args:
+        start: Window start in samples.
+        end: Window end in samples.
+        target: Desired window length in samples.
+        limit: Length of the audio in samples, or ``None`` if unbounded.
+
+    Returns:
+        The widened ``(start, end)`` in samples.
+
+    """
+    deficit = target - (end - start)
+    new_start = start - deficit // 2
+    new_end = new_start + target
+    if new_start < 0:
+        new_start, new_end = 0, target
+    if limit is not None and new_end > limit:
+        new_end, new_start = limit, limit - target
+    return max(0, new_start), new_end
+
+
+def prepare_segments(
+    segments: list[Segment],
+    min_samples_for: "Callable[[str], int]",
+    sample_rate: int = 16000,
+    num_samples: int | None = None,
+) -> list[Segment]:
+    """Widen segments that are too short for a wav2vec2 aligner to time-stamp.
+
+    Long-form Whisper occasionally emits **degenerate micro-segments**: real text with a
+    near-zero span (e.g. ``"I"`` over 0.02 s).  The text is fine and the surrounding audio
+    exists — only the *window* is too narrow to give CTC one emission frame per token.
+    Such a window makes ``MMS_FA`` raise and makes whisperX divide by zero, so the naive
+    remedy is to drop the segment; that throws the word away for no reason.
+
+    Instead, each short segment is grown around its midpoint until it satisfies both
+    floors — :func:`wav2vec2_min_samples` (what the model needs) and
+    :data:`WIDEN_WINDOW_SECONDS` (what the *speech* needs) — clamped to the audio.  The
+    aligner then sees enough audio to actually locate the word, and returns a real
+    timestamp for it instead of nothing.
+
+    Healthy segments are passed through with their span clamped to the audio, and are
+    otherwise untouched: the speech floor applies only to segments already known to be too
+    short for the model, so normal short utterances keep the span Whisper gave them.
+
+    A widened window may overlap its neighbours, so the words two adjacent segments emit
+    can interleave in time; :meth:`ForcedAligner.align_segments` sorts the merged stream.
+
+    Blank-text segments are skipped.  A segment is dropped when the *whole recording* is
+    too short to carry its text, or when it lies entirely past the end of the audio —
+    the two cases widening cannot fix.
+
+    Args:
+        segments: Transcript segments, typically straight from Whisper.
+        min_samples_for: Returns the samples a given text needs. Backends pass their own
+            tokenizer-exact version; see :meth:`ForcedAligner.min_align_samples`.
+        sample_rate: Sample rate of the audio the segments refer to.
+        num_samples: Length of the audio in samples. Windows are clamped to it, so a
+            segment running past the end of the audio is judged on the slice that exists.
+
+    Returns:
+        Alignable segments in chronological order, some with widened spans. Widened and
+        dropped segments are logged so neither is silent.
+
+    """
+    limit = num_samples
+    prepared: list[Segment] = []
+    widened: list[Segment] = []
+    dropped: list[Segment] = []
+
+    for segment in segments:
+        text = segment.text
+        if not text.strip():
+            continue
+
+        start = max(0, int(float(segment.start) * sample_rate))
+        end = max(start, int(float(segment.end) * sample_rate))
+        needed = min_samples_for(text)
+
+        clamped = False
+        if limit is not None:
+            # Widening cannot conjure audio: neither for text longer than the whole
+            # recording, nor for a segment that starts past the end of it.
+            if needed > limit or start >= limit:
+                dropped.append(segment)
+                continue
+            clamped = end > limit
+            end = min(end, limit)
+
+        if end - start >= needed:
+            # A segment overrunning the audio is clamped, so whisperX rescales its
+            # timestamps against the audio it really gets — a nominal end past the file
+            # end would otherwise inflate its frame ratio and stretch the word times.
+            prepared.append(_to_segment(text, start, end, sample_rate) if clamped else segment)
+            continue
+
+        # The span is unusable, so give the word a window it can actually be heard in,
+        # not merely the model's bare minimum — but never more audio than we have.
+        target = max(needed, int(WIDEN_WINDOW_SECONDS * sample_rate))
+        if limit is not None:
+            target = max(needed, min(target, limit))
+
+        new_start, new_end = _widen(start, end, target, limit)
+        prepared.append(_to_segment(text, new_start, new_end, sample_rate))
+        widened.append(segment)
+
+    _log_prepared(segments, widened, dropped)
+    return prepared
+
+
+def _to_segment(text: str, start: int, end: int, sample_rate: int) -> Segment:
+    """Build a :class:`Segment` from a sample-space window."""
+    return Segment(text=text, start=start / sample_rate, end=end / sample_rate)
+
+
+def _log_prepared(segments: list[Segment], widened: list[Segment], dropped: list[Segment]) -> None:
+    """Report widened and dropped segments so neither loss is silent."""
+
+    def preview(items: list[Segment]) -> str:
+        shown = ", ".join(f"{s.text.strip()!r} @ {s.start:.2f}s" for s in items[:5])
+        return shown + (f" (+{len(items) - 5} more)" if len(items) > 5 else "")
+
+    if widened:
+        logger.info(
+            f"Widened {len(widened)}/{len(segments)} segment(s) too short to force-align; "
+            f"their word timings are approximate: {preview(widened)}"
+        )
+    if dropped:
+        logger.warning(
+            f"Dropping {len(dropped)}/{len(segments)} segment(s) the audio cannot carry "
+            f"(too short for their text, or past the end of the recording): "
+            f"{preview(dropped)}"
+        )
 
 
 def to_mono_16k(audio: "Path | str | np.ndarray | torch.Tensor") -> tuple[torch.Tensor, int]:
@@ -357,6 +559,22 @@ class ForcedAligner(ABC):
 
     """
 
+    def min_align_samples(self, text: str) -> int:
+        """Samples this backend needs to align *text*.
+
+        The default counts non-whitespace characters as CTC tokens, which holds for the
+        character-level wav2vec2 models both backends use.  Backends with a tokenizer to
+        hand should override this and count exactly.
+
+        Args:
+            text: The text to be aligned.
+
+        Returns:
+            Minimum slice length in samples.
+
+        """
+        return wav2vec2_min_samples(sum(1 for c in text if not c.isspace()))
+
     @abstractmethod
     def align(
         self,
@@ -388,6 +606,10 @@ class ForcedAligner(ABC):
         length work without exhausting memory. Word times are shifted back onto
         the full-audio timeline by each segment's ``start``.
 
+        Segments too short to align are widened by :func:`prepare_segments` rather than
+        crashing the recording or being thrown away.  Because a widened window may
+        overlap its neighbours, the merged stream is sorted by time at the end.
+
         Backends with a native batched segment API (e.g. whisperX) override this.
 
         Args:
@@ -400,14 +622,11 @@ class ForcedAligner(ABC):
 
         """
         waveform, sample_rate = to_mono_16k(audio)
+        num_samples = waveform.numel()
         words: list[Word] = []
-        for segment in segments:
-            if not segment.text.strip():
-                continue
+        for segment in prepare_segments(segments, self.min_align_samples, sample_rate, num_samples):
             start = max(0, int(segment.start * sample_rate))
-            end = min(waveform.numel(), int(segment.end * sample_rate))
-            if end - start < sample_rate // 100:  # skip <10 ms slivers
-                continue
+            end = min(num_samples, int(segment.end * sample_rate))
             for word in self.align(waveform[start:end], segment.text, language=language):
                 words.append(
                     Word(
@@ -417,6 +636,7 @@ class ForcedAligner(ABC):
                         score=word.score,
                     )
                 )
+        words.sort(key=lambda w: (w.start, w.end))
         return words
 
 

--- a/exordium/text/whisperx_align.py
+++ b/exordium/text/whisperx_align.py
@@ -27,7 +27,12 @@ import numpy as np
 import torch
 
 from exordium.audio.io import load_audio
-from exordium.text.base import ForcedAligner, Segment, Word
+from exordium.text.base import (
+    ForcedAligner,
+    Segment,
+    Word,
+    prepare_segments,
+)
 from exordium.utils.device import get_torch_device
 
 logger = logging.getLogger(__name__)
@@ -91,7 +96,11 @@ class WhisperxForcedAligner(ForcedAligner):
                 given (a mismatch is logged, not enforced).
 
         Returns:
-            Words in chronological order. Empty if *transcript* is blank.
+            Words in chronological order. Empty if *transcript* is blank, or if the
+            audio is too short to carry it — see
+            :func:`~exordium.text.base.wav2vec2_min_samples`.  Callers aligning whole
+            recordings should go through :meth:`align_segments`, which widens short
+            windows instead of giving up on them.
 
         """
         self._warn_language(language)
@@ -99,6 +108,14 @@ class WhisperxForcedAligner(ForcedAligner):
             return []
 
         waveform, sr = self._to_array(audio)
+        needed = self.min_align_samples(transcript)
+        if len(waveform) < needed:
+            # Too few frames: whisperX divides by zero, or backtracks to untimed words.
+            logger.warning(
+                f"Audio is {len(waveform)} samples but the transcript needs {needed} "
+                "to force-align; returning []."
+            )
+            return []
         duration = len(waveform) / sr
         return self._run([{"text": transcript, "start": 0.0, "end": duration}], waveform)
 
@@ -114,6 +131,17 @@ class WhisperxForcedAligner(ForcedAligner):
         already on the full-audio timeline, so long recordings stay bounded
         without the per-segment Python loop of the base implementation.
 
+        Segments too short for whisperX to align are widened first by
+        :func:`~exordium.text.base.prepare_segments`.  whisperX pads a short slice up to
+        wav2vec2's input floor, but then rescales its timestamps by
+        ``duration / (trellis.size(0) - 1)`` — a one-row trellis divides by zero and
+        aborts the entire recording.  Even when it survives that, a frame-starved
+        segment fails backtrack and comes back *untimed*, so its words are silently
+        dropped.  Widening the window fixes both.
+
+        Because a widened window may overlap its neighbours, the merged word stream is
+        sorted by time before it is returned.
+
         Args:
             audio: Full audio — file path, numpy array, or torch tensor.
             segments: Timestamped transcript segments covering the audio.
@@ -124,15 +152,18 @@ class WhisperxForcedAligner(ForcedAligner):
 
         """
         self._warn_language(language)
+        if not segments:
+            return []
+        waveform, sr = self._to_array(audio)
         payload = [
             {"text": s.text, "start": float(s.start), "end": float(s.end)}
-            for s in segments
-            if s.text.strip()
+            for s in prepare_segments(segments, self.min_align_samples, sr, len(waveform))
         ]
         if not payload:
             return []
-        waveform, _ = self._to_array(audio)
-        return self._run(payload, waveform)
+        words = self._run(payload, waveform)
+        words.sort(key=lambda w: (w.start, w.end))
+        return words
 
     def _warn_language(self, language: str | None) -> None:
         """Log when a caller asks for a language the loaded model was not built for."""

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,16 +1,55 @@
 """Test fixture paths and lightweight weight-availability helpers."""
 
+import contextlib
 import gc
+import logging
 import pathlib
 import types
 import unittest
 import urllib.request
+from collections.abc import Iterator
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from http.client import HTTPResponse
 
 FIXTURES_ROOT = pathlib.Path(__file__).parent
+
+
+def best_anchored_word(words: list) -> object:
+    """Pick the word whose own alignment is trustworthy enough to test against.
+
+    The speech fixtures' reference transcripts cover only part of a long multi-speaker
+    recording, so an aligner smears the unmatched tail across huge spans (whole "words"
+    lasting 12 s). Only tightly-bounded, high-confidence words are usable as ground truth.
+
+    Args:
+        words: Word stream from a forced aligner.
+
+    Returns:
+        The highest-scoring word with a plausible duration.
+
+    """
+    anchored = [w for w in words if 0.05 <= (w.end - w.start) <= 0.4]
+    return max(anchored, key=lambda w: w.score)
+
+
+@contextlib.contextmanager
+def logging_enabled() -> Iterator[None]:
+    """Undo the suite-wide ``logging.disable(WARNING)`` for one block.
+
+    ``tests/__init__`` silences warnings so model-loading noise stays out of the
+    test output, but that also stops :meth:`~unittest.TestCase.assertLogs` from
+    ever seeing a record. Wrap a block in this to assert on log output::
+
+        with logging_enabled(), self.assertLogs("exordium.text.base", "WARNING"):
+            ...
+    """
+    logging.disable(logging.NOTSET)
+    try:
+        yield
+    finally:
+        logging.disable(logging.WARNING)
 
 
 def free_torch_memory() -> None:

--- a/tests/text/test_alignment.py
+++ b/tests/text/test_alignment.py
@@ -9,9 +9,14 @@ from exordium.text.alignment import (
     WhisperWordTimestamper,
     normalize_words,
 )
-from exordium.text.base import Segment, Word
+from exordium.text.base import MIN_ALIGN_SAMPLES, Segment, Word
 from exordium.text.transcript_align import find_segment
-from tests.fixtures import AUDIO_MULTISPEAKER, ModelTestCase
+from tests.fixtures import (
+    AUDIO_MULTISPEAKER,
+    ModelTestCase,
+    best_anchored_word,
+    logging_enabled,
+)
 
 
 class TestNormalizeWords(unittest.TestCase):
@@ -83,6 +88,60 @@ class TestTorchaudioForcedAligner(ModelTestCase):
         ]
         words = self.aligner.align_segments(AUDIO_MULTISPEAKER, segments)
         self.assertEqual([w.text for w in words], ["hey"])
+
+    def test_align_segments_recovers_degenerate_micro_segment(self):
+        # Regression: Whisper long-form emits real text spanning ~0.02s. The slice was
+        # below MMS_FA's conv floor, which raised and killed the whole recording. The
+        # word must not merely survive the crash — it must come back timed.
+        segments = [
+            Segment(text="hey guys", start=0.0, end=2.0),
+            Segment(text="that", start=2.100, end=2.120),  # degenerate: 320 samples
+            Segment(text="what do you guys want to eat", start=2.5, end=6.0),
+        ]
+        words = self.aligner.align_segments(AUDIO_MULTISPEAKER, segments)
+        self.assertIn("that", [w.text for w in words])
+        starts = [w.start for w in words]
+        self.assertEqual(starts, sorted(starts))
+
+    def test_recovered_degenerate_word_matches_ground_truth_timing(self):
+        # The point of widening is not just "no crash" — the word must come back timed
+        # *correctly*. Align the full sentence for ground truth, then re-align one of its
+        # words as a degenerate 0.02s micro-segment and check we land back on it.
+        target = best_anchored_word(
+            self.aligner.align(
+                AUDIO_MULTISPEAKER, "Hey guys, what do you guys want to eat for lunch?"
+            )
+        )
+        midpoint = (target.start + target.end) / 2
+        degenerate = [Segment(text=target.text, start=midpoint, end=midpoint + 0.02)]
+
+        words = self.aligner.align_segments(AUDIO_MULTISPEAKER, degenerate)
+        self.assertEqual([w.text for w in words], [target.text])
+        # Recovered to within ~2 emission frames of where the word really is. Without the
+        # speech-realistic floor the window clips the word and this drifts by >100 ms.
+        self.assertAlmostEqual(words[0].start, target.start, delta=0.1)
+        self.assertAlmostEqual(words[0].end, target.end, delta=0.1)
+
+    def test_min_align_samples_uses_the_models_own_tokenizer(self):
+        # normalize_words strips punctuation, so it must not inflate the requirement.
+        self.assertEqual(
+            self.aligner.min_align_samples("that!"), self.aligner.min_align_samples("that")
+        )
+        # Longer text genuinely needs more frames, hence more audio.
+        self.assertGreater(
+            self.aligner.min_align_samples("that"), self.aligner.min_align_samples("i")
+        )
+
+    def test_min_align_samples_falls_back_for_untokenizable_text(self):
+        # Punctuation-only text has no MMS_FA tokens; fall back to the two-frame floor
+        # rather than computing a requirement from zero tokens.
+        self.assertEqual(self.aligner.min_align_samples("..."), MIN_ALIGN_SAMPLES)
+
+    def test_align_on_audio_too_short_for_its_text_returns_empty(self):
+        # align() is the raw single-shot path: it cannot widen, so it declines.
+        waveform = np.zeros(MIN_ALIGN_SAMPLES, dtype=np.float32)
+        with logging_enabled(), self.assertLogs("exordium.text.alignment", level="WARNING"):
+            self.assertEqual(self.aligner.align(waveform, "that"), [])
 
 
 class TestWhisperWordTimestamper(ModelTestCase):

--- a/tests/text/test_base.py
+++ b/tests/text/test_base.py
@@ -1,0 +1,168 @@
+"""Tests for the shared text/alignment base helpers."""
+
+import unittest
+
+from exordium.text.base import (
+    MIN_ALIGN_SAMPLES,
+    WAV2VEC2_RECEPTIVE_FIELD_SAMPLES,
+    WAV2VEC2_STRIDE_SAMPLES,
+    WIDEN_WINDOW_SECONDS,
+    Segment,
+    prepare_segments,
+    wav2vec2_min_samples,
+)
+from tests.fixtures import logging_enabled
+
+SAMPLE_RATE = 16000
+
+
+def chars(text: str) -> int:
+    """Token count the way the base class estimates it."""
+    return sum(1 for c in text if not c.isspace())
+
+
+def min_samples(text: str) -> int:
+    """The default ``min_samples_for`` callback used across these tests."""
+    return wav2vec2_min_samples(chars(text))
+
+
+class TestWav2vec2MinSamples(unittest.TestCase):
+    """The frames-per-token bound that decides how much audio a text needs."""
+
+    def test_emission_frames_cover_every_token(self):
+        # The contract: floor((N - 400) / 320) + 1 >= num_tokens.
+        for num_tokens in range(1, 30):
+            n = wav2vec2_min_samples(num_tokens)
+            frames = (n - WAV2VEC2_RECEPTIVE_FIELD_SAMPLES) // WAV2VEC2_STRIDE_SAMPLES + 1
+            self.assertGreaterEqual(frames, num_tokens, f"{num_tokens} tokens got {frames} frames")
+
+    def test_is_tight_not_merely_sufficient(self):
+        # One stride less must be too few frames, or we are wasting audio.
+        for num_tokens in range(3, 30):
+            n = wav2vec2_min_samples(num_tokens) - WAV2VEC2_STRIDE_SAMPLES
+            frames = (n - WAV2VEC2_RECEPTIVE_FIELD_SAMPLES) // WAV2VEC2_STRIDE_SAMPLES + 1
+            self.assertLess(frames, num_tokens)
+
+    def test_never_below_the_two_frame_floor(self):
+        # A single frame divides by zero in whisperX regardless of token count.
+        self.assertEqual(wav2vec2_min_samples(1), MIN_ALIGN_SAMPLES)
+        self.assertEqual(wav2vec2_min_samples(0), MIN_ALIGN_SAMPLES)
+
+    def test_grows_with_token_count(self):
+        self.assertGreater(wav2vec2_min_samples(4), wav2vec2_min_samples(1))
+
+
+class TestPrepareSegments(unittest.TestCase):
+    """Widening degenerate Whisper micro-segments instead of discarding them."""
+
+    def test_keeps_normal_segments_untouched(self):
+        segments = [
+            Segment(text="hey guys", start=0.0, end=2.0),
+            Segment(text="what do you want to eat", start=2.0, end=6.0),
+        ]
+        self.assertEqual(prepare_segments(segments, min_samples, SAMPLE_RATE), segments)
+
+    def test_widens_degenerate_micro_segment_instead_of_dropping_it(self):
+        # Regression: Whisper long-form emits real text with a ~0.02s span. The word is
+        # real and the audio around it exists, so it must survive with usable timings.
+        segments = [Segment(text="that", start=123.880, end=123.900)]
+        prepared = prepare_segments(segments, min_samples, SAMPLE_RATE, num_samples=200 * 16000)
+        self.assertEqual(len(prepared), 1)
+        self.assertEqual(prepared[0].text, "that")
+        span = int(prepared[0].end * SAMPLE_RATE) - int(prepared[0].start * SAMPLE_RATE)
+        self.assertGreaterEqual(span, min_samples("that"))
+
+    def test_widened_window_clears_the_speech_floor_not_just_the_model_floor(self):
+        # The geometric minimum for "that" is only ~85ms, but the word takes ~250ms to
+        # say; a window that tight clips it and the timestamp comes back truncated.
+        segments = [Segment(text="that", start=10.0, end=10.02)]
+        prepared = prepare_segments(segments, min_samples, SAMPLE_RATE, num_samples=20 * 16000)
+        span = prepared[0].end - prepared[0].start
+        self.assertGreaterEqual(span, WIDEN_WINDOW_SECONDS)
+
+    def test_healthy_short_segments_are_left_alone(self):
+        # The speech floor must not reshape spans Whisper got right; only degenerate
+        # segments (below the model's own requirement) are widened.
+        segments = [Segment(text="hey", start=1.0, end=1.2)]
+        self.assertEqual(prepare_segments(segments, min_samples, SAMPLE_RATE), segments)
+
+    def test_widened_window_stays_centred_on_the_original(self):
+        segments = [Segment(text="I", start=10.0, end=10.02)]
+        prepared = prepare_segments(segments, min_samples, SAMPLE_RATE, num_samples=20 * 16000)
+        # The word is still where Whisper heard it, just with room to breathe.
+        self.assertLess(prepared[0].start, 10.0)
+        self.assertGreater(prepared[0].end, 10.02)
+        self.assertAlmostEqual((prepared[0].start + prepared[0].end) / 2, 10.01, places=2)
+
+    def test_widening_is_clamped_to_the_audio(self):
+        num_samples = 5 * SAMPLE_RATE
+        for segment in (
+            Segment(text="that", start=0.0, end=0.02),  # at the very start
+            Segment(text="that", start=4.99, end=5.0),  # at the very end
+        ):
+            prepared = prepare_segments([segment], min_samples, SAMPLE_RATE, num_samples)
+            self.assertEqual(len(prepared), 1)
+            self.assertGreaterEqual(prepared[0].start, 0.0)
+            self.assertLessEqual(prepared[0].end, num_samples / SAMPLE_RATE)
+            span = int(prepared[0].end * SAMPLE_RATE) - int(prepared[0].start * SAMPLE_RATE)
+            self.assertGreaterEqual(span, min_samples("that"))
+
+    def test_drops_only_when_the_audio_itself_is_too_short(self):
+        # Widening cannot conjure audio that does not exist.
+        segments = [Segment(text="a much longer sentence than this audio", start=0.0, end=0.02)]
+        prepared = prepare_segments([*segments], min_samples, SAMPLE_RATE, num_samples=800)
+        self.assertEqual(prepared, [])
+
+    def test_drops_segment_starting_past_the_end_of_the_audio(self):
+        # Whisper can emit an end (or start) beyond the true duration. Widening such a
+        # segment would silently align it to the last window of the recording and hand
+        # back a confidently-wrong timestamp, so it must be dropped instead.
+        num_samples = 5 * SAMPLE_RATE
+        segments = [Segment(text="ghost", start=6.0, end=6.02)]
+        self.assertEqual(prepare_segments(segments, min_samples, SAMPLE_RATE, num_samples), [])
+
+    def test_kept_segment_overrunning_the_audio_is_clamped(self):
+        # Left unclamped, whisperX rescales timestamps by a nominal duration longer than
+        # the audio it actually slices, inflating its frame ratio and stretching the word
+        # times past the end of the recording.
+        num_samples = 5 * SAMPLE_RATE
+        segments = [Segment(text="overrun", start=4.0, end=9.0)]
+        prepared = prepare_segments(segments, min_samples, SAMPLE_RATE, num_samples)
+        self.assertEqual(len(prepared), 1)
+        self.assertEqual(prepared[0].end, num_samples / SAMPLE_RATE)
+        self.assertEqual(prepared[0].start, 4.0)
+
+    def test_drops_blank_text_segments(self):
+        good = Segment(text="hey", start=0.0, end=2.0)
+        segments = [Segment(text="   ", start=0.0, end=2.0), good]
+        self.assertEqual(prepare_segments(segments, min_samples, SAMPLE_RATE), [good])
+
+    def test_segment_running_past_end_of_audio_is_widened_backwards(self):
+        num_samples = SAMPLE_RATE  # 1 second of audio
+        segments = [Segment(text="trailing", start=0.99, end=5.0)]
+        prepared = prepare_segments(segments, min_samples, SAMPLE_RATE, num_samples)
+        self.assertEqual(len(prepared), 1)
+        self.assertLessEqual(prepared[0].end, 1.0)
+        self.assertLess(prepared[0].start, 0.99)
+
+    def test_logs_widened_and_dropped_segments(self):
+        with logging_enabled(), self.assertLogs("exordium.text.base") as logs:
+            prepare_segments(
+                [Segment(text="that", start=1.0, end=1.02)],
+                min_samples,
+                SAMPLE_RATE,
+                num_samples=10 * SAMPLE_RATE,
+            )
+        self.assertIn("Widened", logs.output[0])
+        with logging_enabled(), self.assertLogs("exordium.text.base", level="WARNING") as logs:
+            prepare_segments(
+                [Segment(text="that", start=0.0, end=0.02)], min_samples, SAMPLE_RATE, 500
+            )
+        self.assertIn("Dropping", logs.output[0])
+
+    def test_empty_input_returns_empty(self):
+        self.assertEqual(prepare_segments([], min_samples, SAMPLE_RATE), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/text/test_whisperx_align.py
+++ b/tests/text/test_whisperx_align.py
@@ -2,10 +2,17 @@
 
 import unittest
 
+import numpy as np
+
 from exordium.text import whisperx_align
-from exordium.text.base import Segment, Word
+from exordium.text.base import MIN_ALIGN_SAMPLES, Segment, Word
 from exordium.text.transcript_align import find_segment
-from tests.fixtures import AUDIO_MULTISPEAKER, ModelTestCase
+from tests.fixtures import (
+    AUDIO_MULTISPEAKER,
+    ModelTestCase,
+    best_anchored_word,
+    logging_enabled,
+)
 
 WHISPERX_AVAILABLE = whisperx_align._WHISPERX_AVAILABLE
 
@@ -58,6 +65,63 @@ class TestWhisperxForcedAligner(ModelTestCase):
 
     def test_align_segments_empty_returns_empty(self):
         self.assertEqual(self.aligner.align_segments(AUDIO_MULTISPEAKER, []), [])
+
+    def test_align_segments_recovers_degenerate_micro_segments(self):
+        # Regression: Whisper long-form emits real text with a near-zero duration.
+        # Any slice under MIN_ALIGN_SAMPLES collapses to a single emission frame, and
+        # whisperX rescales timestamps by `duration * ... / (trellis.size(0) - 1)` —
+        # a one-row trellis divides by zero and aborts the entire recording.
+        #
+        # The "I" segments are the teeth of this test: a 400-sample floor (wav2vec2's
+        # own minimum, and the obvious guess for the guard) still lets them through,
+        # because a single-character text is short enough for whisperX's backtrack to
+        # *succeed* on one frame and reach the division.
+        segments = [
+            Segment(text="hey guys", start=0.0, end=2.0),
+            Segment(text="that", start=2.100, end=2.120),  # 320 samples
+            Segment(text="I", start=2.200, end=2.230),  # 480 samples: past a 400 floor
+            Segment(text="I", start=2.300, end=2.340),  # 640 samples: past a 400 floor
+            Segment(text="what do you guys want to eat", start=2.5, end=6.0),
+        ]
+        words = self.aligner.align_segments(AUDIO_MULTISPEAKER, segments)
+        # Every degenerate word comes back timed, not dropped.
+        text = [w.text.strip().lower().strip(".,!?") for w in words]
+        self.assertIn("that", text)
+        self.assertEqual(text.count("i"), 2)
+        starts = [w.start for w in words]
+        self.assertEqual(starts, sorted(starts))
+
+    def test_recovered_degenerate_word_matches_ground_truth_timing(self):
+        # Widening must return the word *correctly* timed, not merely return it. Align
+        # the full sentence for ground truth, then re-align one word as a degenerate
+        # 0.02s micro-segment and check we land back on it.
+        target = best_anchored_word(
+            self.aligner.align(
+                AUDIO_MULTISPEAKER, "Hey guys, what do you guys want to eat for lunch?"
+            )
+        )
+        midpoint = (target.start + target.end) / 2
+        degenerate = [Segment(text=target.text, start=midpoint, end=midpoint + 0.02)]
+
+        words = self.aligner.align_segments(AUDIO_MULTISPEAKER, degenerate)
+        self.assertEqual(len(words), 1)
+        # Tolerance is looser than the torchaudio equivalent because whisperX's
+        # character-level timings are coarser, but still far tighter than the widened
+        # window: this asserts the word was *located*, not merely returned.
+        self.assertAlmostEqual(words[0].start, target.start, delta=0.25)
+
+    def test_align_segments_all_unalignable_returns_empty(self):
+        # Audio too short to carry any of the text: every segment is dropped, so the
+        # payload is empty and whisperX is never called.
+        waveform = np.zeros(MIN_ALIGN_SAMPLES, dtype=np.float32)
+        segments = [Segment(text="far too much text for this audio", start=0.0, end=0.02)]
+        with logging_enabled(), self.assertLogs("exordium.text.base", level="WARNING"):
+            self.assertEqual(self.aligner.align_segments(waveform, segments), [])
+
+    def test_align_on_audio_too_short_for_its_text_returns_empty(self):
+        waveform = np.zeros(MIN_ALIGN_SAMPLES, dtype=np.float32)
+        with logging_enabled(), self.assertLogs("exordium.text.whisperx_align", "WARNING"):
+            self.assertEqual(self.aligner.align(waveform, "that"), [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
See commit body — widens degenerate Whisper micro-segments instead of crashing forced alignment in both the whisperX and torchaudio backends.