### PR TITLE
feat(video): add FaRL face wrapper; serve EmotiEffNet and FaRL weights from the mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Exordium is a comprehensive toolkit for **multimodal feature extraction** across
 | Vision–language embeddings | [CLIP](https://huggingface.co/laion/CLIP-ViT-H-14-laion2B-s32B-b79K) (ViT-H/14, laion2B) | 1024-d |
 | Self-supervised visual features | [DINOv2](https://huggingface.co/facebook/dinov2-base) (small/base/large/giant) | 384 / 768 / 1024 / 1536-d |
 | Facial expression features | [EmotiEffNet](https://github.com/sb-ai-lab/EmotiEffLib) (EfficientNet-B0/B2, AffectNet) | 1280-d / 1408-d |
+| Universal face features | [FaRL](https://github.com/FacePerceiver/FaRL) (CLIP ViT-B/16, LAION-Face 20M, CVPR 2022) | 512-d |
 | Facial video features | [MARLIN](https://github.com/ControlNet/MARLIN) (ViT, 16-frame clips, CVPR 2023) | 384 / 768 / 1024-d |
 
 ### Text

--- a/examples/demo_video_deep_face.ipynb
+++ b/examples/demo_video_deep_face.ipynb
@@ -1,0 +1,332 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Face Feature Extractors — EmotiEffNet / FaRL\n",
+    "\n",
+    "Two complementary frozen face encoders for affect, personality and sentiment\n",
+    "pipelines. Both are **frame-wise** — no 16-frame clip buffering, unlike MARLIN —\n",
+    "so they run comfortably in interactive settings and accept either a single face\n",
+    "image or a face `Track`.\n",
+    "\n",
+    "| Model | Wrapper | Output | Input | Pre-training | Weights licence |\n",
+    "|---|---|---|---|---|---|\n",
+    "| EmotiEffNet B0/B2 | `EmotiEffNetWrapper` | 1280 / 1408-d | 224 / 260 | VGGFace2 → AffectNet (8 expressions) | Apache-2.0 |\n",
+    "| FaRL ViT-B/16 | `FarlWrapper` | 512-d | 224 | LAION-Face 20M (image–text + MIM) | MIT |\n",
+    "\n",
+    "**How they differ.** EmotiEffNet is *supervised* on expression labels, so its\n",
+    "features are tuned for emotion/valence–arousal but discard cues its 8-class head\n",
+    "never needed. FaRL is *self-supervised* and vision-language pretrained, so it\n",
+    "keeps identity-ish, appearance and style cues — the things apparent-personality\n",
+    "prediction leans on — and its paper reports strong transfer in the low-data\n",
+    "regimes that personality corpora live in. They are meant to be **concatenated**,\n",
+    "not chosen between.\n",
+    "\n",
+    "This notebook downloads **real pretrained weights** (the test suite deliberately\n",
+    "does not) and checks the features actually behave — that is the point of running\n",
+    "it.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "import torch\n",
+    "import torch.nn.functional as F\n",
+    "\n",
+    "from exordium.video.deep import EmotiEffNetWrapper, FarlWrapper\n",
+    "\n",
+    "DEVICE_ID = -1  # -1 → CPU; set to a GPU index to use CUDA\n",
+    "\n",
+    "FIXTURES = Path(\"../tests/fixtures/image\")\n",
+    "FACE = FIXTURES / \"face.jpg\"\n",
+    "EMMA = FIXTURES / \"emma.jpg\"\n",
+    "CAT = FIXTURES / \"cat_tie.jpg\"  # not a face → the negative control\n",
+    "\n",
+    "print(\"face:\", FACE.exists(), \"| emma:\", EMMA.exists(), \"| cat:\", CAT.exists())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Single face image\n",
+    "\n",
+    "Every wrapper takes a path, a numpy array, or a tensor, and returns `(B, D)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "emotieffnet = EmotiEffNetWrapper(model_name=\"enet_b0_8_best_vgaf\", device_id=DEVICE_ID)\n",
+    "farl = FarlWrapper(model_name=\"ep64\", device_id=DEVICE_ID)\n",
+    "\n",
+    "models = {\"EmotiEffNet-B0\": emotieffnet, \"FaRL-B/16\": farl}\n",
+    "\n",
+    "for name, model in models.items():\n",
+    "    feat = model(FACE)\n",
+    "    print(f\"{name:15s} {tuple(feat.shape)}  dim={model.feature_dim}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Does it actually work?\n",
+    "\n",
+    "Loading without error proves nothing — a randomly-initialised model produces\n",
+    "correctly-shaped features too. So how do you *check* a frozen feature extractor?\n",
+    "\n",
+    "The property that separates trained from untrained features is whether a\n",
+    "**semantic label is readable** from them. The check below does that against\n",
+    "ground truth for EmotiEffNet; the section after it is candid about why the same\n",
+    "trick does not work for the self-supervised pair, and what to do instead."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Check 1 — EmotiEffNet against ground truth\n",
+    "\n",
+    "EmotiEffNet is supervised, so it carries its own semantic label set: the 8\n",
+    "AffectNet expression classes. Re-attach its classifier head and the features are\n",
+    "verifiable directly against something we can look at with our own eyes — a thing\n",
+    "random weights cannot fake."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import timm\n",
+    "import torchvision.transforms.functional as TF\n",
+    "\n",
+    "from exordium import WEIGHT_DIR\n",
+    "from exordium.video.core.io import to_uint8_tensor\n",
+    "from exordium.video.deep.emotieffnet import _MODELS, _load_state_dict_from_pickle\n",
+    "\n",
+    "AFFECTNET = [\"Anger\", \"Contempt\", \"Disgust\", \"Fear\", \"Happiness\", \"Neutral\", \"Sadness\", \"Surprise\"]\n",
+    "\n",
+    "# Same checkpoint the wrapper loads, but keeping the classification head that\n",
+    "# EmotiEffNetWrapper replaces with Identity.\n",
+    "variant = \"enet_b0_8_best_vgaf\"\n",
+    "cfg = _MODELS[variant]\n",
+    "classifier = timm.create_model(cfg[\"timm_name\"], pretrained=False, num_classes=8)\n",
+    "classifier.load_state_dict(\n",
+    "    _load_state_dict_from_pickle(str(WEIGHT_DIR / \"emotieffnet\" / f\"{variant}.pt\"))\n",
+    ")\n",
+    "classifier.eval()\n",
+    "\n",
+    "IMAGENET_MEAN = torch.tensor([0.485, 0.456, 0.406]).view(1, 3, 1, 1)\n",
+    "IMAGENET_STD = torch.tensor([0.229, 0.224, 0.225]).view(1, 3, 1, 1)\n",
+    "\n",
+    "for path in (FACE, EMMA):\n",
+    "    x = TF.resize(to_uint8_tensor(path), [224, 224], antialias=True).float().div(255)\n",
+    "    with torch.inference_mode():\n",
+    "        probs = classifier((x - IMAGENET_MEAN) / IMAGENET_STD).softmax(-1)[0]\n",
+    "    top3 = probs.argsort(descending=True)[:3]\n",
+    "    print(f\"{path.name:10s} \" + \"   \".join(f\"{AFFECTNET[i]}={probs[i]:.2f}\" for i in top3))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Open `tests/fixtures/image/face.jpg` and compare: wide eyes, raised brows, pursed\n",
+    "lips. A confident *Surprise* is the right call. The checkpoint is loaded\n",
+    "correctly and the penultimate features the wrapper returns are the ones feeding\n",
+    "that decision."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Check 2 — determinism and the limits of a two-image sanity check\n",
+    "\n",
+    "FaRL is self-supervised, so it has no ground-truth head to check against. What\n",
+    "*can* be verified cheaply is that it is deterministic, produces unit-norm\n",
+    "embeddings, and is sensitive to the input:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for name, model in models.items():\n",
+    "    with torch.inference_mode():\n",
+    "        a = model(FACE)\n",
+    "        b = model(FACE)  # same input, twice\n",
+    "        c = model(EMMA)  # different face\n",
+    "    print(\n",
+    "        f\"{name:15s} deterministic={torch.allclose(a, b)}  \"\n",
+    "        f\"‖e‖={float(F.normalize(a.float(), dim=-1).norm()):.3f}  \"\n",
+    "        f\"differs on a different face={not torch.allclose(a, c)}\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**And now the honest caveat, because it matters more than a green checkmark.**\n",
+    "\n",
+    "It is tempting to go further here — cluster the two faces against the cat, or\n",
+    "probe *face vs. scrambled-face* — and declare the weights validated. Those tests\n",
+    "were tried while writing this notebook and **every one of them is also passed by\n",
+    "a randomly-initialised model**, so they prove nothing. A random ViT is still a\n",
+    "smooth, high-dimensional projection: near-identical inputs give near-identical\n",
+    "outputs, distinct inputs stay linearly separable, and raw cosine geometry tracks\n",
+    "colour and texture statistics rather than anything learned. Untrained features\n",
+    "are not noise; they are merely *not organised around anything semantic*.\n",
+    "\n",
+    "Separating a trained face encoder from an untrained one needs a label that only\n",
+    "face knowledge can predict, measured over **many identities under matched\n",
+    "conditions** — the two fixture images in this repo cannot do it, and a notebook\n",
+    "that claimed otherwise would be lying to you.\n",
+    "\n",
+    "So: Check 1 is the real evidence that the checkpoint plumbing is correct\n",
+    "(a supervised head, verifiable against ground truth, on shared preprocessing).\n",
+    "For FaRL, the honest validation is the one you run on *your* data:\n",
+    "\n",
+    "```python\n",
+    "feats = model.track_to_feature(track)[\"features\"]   # (T, D), frozen\n",
+    "# fit a linear/ridge head on your labels; compare against the other encoders\n",
+    "```\n",
+    "\n",
+    "That ablation — which encoder, or which concatenation, linearly predicts *your*\n",
+    "emotion / personality / valence target — is the only comparison that answers the\n",
+    "question you actually have, and it is far cheaper than fine-tuning to find out."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Face track\n",
+    "\n",
+    "`track_to_feature` runs the encoder over every non-interpolated detection in a\n",
+    "`Track` and returns aligned `frame_ids` + `features`. Crops are taken per-frame,\n",
+    "so their sizes drift as the box moves — the wrappers resize internally, so a\n",
+    "ragged track just works."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from exordium.video.core.detection import DetectionFromTorchTensor, Track\n",
+    "\n",
+    "\n",
+    "def demo_track(num_frames: int = 8) -> Track:\n",
+    "    \"\"\"A synthetic track whose box drifts in size, as a tracked face does.\"\"\"\n",
+    "    frame = torch.randint(0, 255, (3, 400, 400), dtype=torch.uint8)\n",
+    "    landmarks = torch.zeros(5, 2, dtype=torch.long)\n",
+    "    track = Track(track_id=0)\n",
+    "    for fid in range(num_frames):\n",
+    "        side = 100 + (fid % 5) * 12  # crop size changes frame to frame\n",
+    "        xy = 200 - side // 2\n",
+    "        track.add(\n",
+    "            DetectionFromTorchTensor(\n",
+    "                frame_id=fid,\n",
+    "                source=frame,\n",
+    "                score=0.99,\n",
+    "                bb_xywh=torch.tensor([xy, xy, side, side], dtype=torch.long),\n",
+    "                landmarks=landmarks,\n",
+    "            )\n",
+    "        )\n",
+    "    return track\n",
+    "\n",
+    "\n",
+    "track = demo_track()\n",
+    "print(f\"track with {len(track)} detections, crop sizes vary per frame\\n\")\n",
+    "\n",
+    "for name, model in models.items():\n",
+    "    out = model.track_to_feature(track, batch_size=4)\n",
+    "    print(\n",
+    "        f\"{name:15s} features={tuple(out['features'].shape)}  frame_ids={out['frame_ids'].tolist()}\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "On a real video you would build the track with the face detector / protagonist\n",
+    "extractor (see `demo_video_protagonist.ipynb`) and pass `output_path=...` to\n",
+    "cache the features to a safetensors file."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Fusing the two\n",
+    "\n",
+    "The point of these encoders is to be concatenated — with each other and with the\n",
+    "non-face streams (DINOv2 on the full frame, WavLM / emotion2vec+ on audio,\n",
+    "XLM-R on the transcript) — and fed to a temporal head.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with torch.inference_mode():\n",
+    "    face_feature = torch.cat([model(FACE).float() for model in models.values()], dim=-1)\n",
+    "\n",
+    "dims = \" + \".join(str(m.feature_dim) for m in models.values())\n",
+    "print(f\"fused face feature: {dims} = {face_feature.shape[-1]}-d\")\n",
+    "print(f\"shape: {tuple(face_feature.shape)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Per frame that is a 1792-d face descriptor (1280 + 512). Concatenate it with\n",
+    "your full-frame and audio streams, aggregate over time (mean/attention/TCN\n",
+    "/ BiLSTM), and train the head — which is where the temporal modelling belongs\n",
+    "once the backbones are frozen.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "exordium",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/exordium/utils/ckpt.py
+++ b/exordium/utils/ckpt.py
@@ -89,6 +89,7 @@ def download_weight(
     repo_id: str = _HF_REPO_ID,
     upstream_repo_id: str | None = None,
     upstream_filename: str | None = None,
+    upstream_url: str | None = None,
 ) -> Path:
     """Download a model weight file from Hugging Face Hub if not already cached.
 
@@ -96,9 +97,13 @@ def download_weight(
     *local_dir*.  Subsequent calls with the same arguments are no-ops.
 
     The mirror is preferred because upstream sources move or vanish (the 6DRepNet
-    author's original link already did).  When *upstream_repo_id* is given it is used as
-    a **fallback**: if the mirror is unreachable or missing the file, the original source
+    author's original link already did).  When an upstream is given it is used as a
+    **fallback**: if the mirror is unreachable or missing the file, the original source
     is tried before giving up, so neither location is a single point of failure.
+
+    The fallback may be another Hub repo (*upstream_repo_id*) or a plain URL
+    (*upstream_url*), since not every upstream publishes to the Hub — EmotiEffLib, for
+    instance, serves its checkpoints straight from GitHub.
 
     Args:
         filename: Name of the file in *repo_id* (e.g. ``"fabnet_weights.pth"``).
@@ -108,6 +113,7 @@ def download_weight(
         upstream_repo_id: Original Hub repo, used only if *repo_id* fails.
         upstream_filename: Filename within *upstream_repo_id*, if it differs from
             *filename*. Defaults to *filename*.
+        upstream_url: Original download URL, used only if the Hub sources fail.
 
     Returns:
         Path to the downloaded (or already cached) local file.
@@ -146,9 +152,19 @@ def download_weight(
             return local_path
         logger.warning(f"{source_repo}/{source_file} reported success but {local_path} is missing")
 
-    raise FileNotFoundError(
-        f"Could not download {filename!r} from any of: {[repo for repo, _ in sources]}"
-    )
+    if upstream_url is not None:
+        try:
+            logger.info(f"Falling back to {upstream_url} → {local_path}")
+            download_file(upstream_url, local_path)
+        except Exception as error:  # noqa: BLE001 - any network failure exhausts the sources
+            logger.warning(f"Could not fetch {upstream_url}: {error}")
+        if local_path.exists():
+            return local_path
+
+    attempted = [f"{repo}/{name}" for repo, name in sources]
+    if upstream_url is not None:
+        attempted.append(upstream_url)
+    raise FileNotFoundError(f"Could not download {filename!r} from any of: {attempted}")
 
 
 def remove_token(weights: dict, token: str = "_model.") -> dict:

--- a/exordium/video/core/io.py
+++ b/exordium/video/core/io.py
@@ -721,6 +721,14 @@ def to_uint8_tensor(
     Canonical shared implementation used by all model wrappers in the library.
     Avoids the need to duplicate this logic across multiple wrapper classes.
 
+    Sequence elements may have **different spatial sizes** — a face track's boxes
+    drift frame to frame, and edge clipping can even make a crop non-square, so
+    ``[det.crop() for det in track]`` is generally ragged. Such a batch cannot be
+    stacked directly, so the elements are resized to a common size (that of the
+    first element) before stacking. Every wrapper resizes to its own fixed input
+    resolution in ``preprocess`` immediately afterwards, so this only picks the
+    intermediate size, not the one the model sees.
+
     Args:
         frames: One of:
 
@@ -728,6 +736,7 @@ def to_uint8_tensor(
             * ``np.ndarray (H, W, 3)`` or ``(B, H, W, 3)`` uint8 RGB
             * ``str | Path`` — single image file path
             * ``Sequence[np.ndarray]`` of ``(H, W, 3)`` arrays
+            * ``Sequence[torch.Tensor]`` of ``(3, H, W)`` or ``(H, W, 3)`` tensors
             * ``Sequence[str | Path]`` of image file paths
 
     Returns:
@@ -753,11 +762,22 @@ def to_uint8_tensor(
     items = list(frames)
     if not items:
         raise ValueError("Empty sequence passed to to_uint8_tensor")
-    if isinstance(items[0], (str, Path)):
-        items = [image_to_np(p, "RGB") for p in items]
-    return torch.stack(
-        [torch.from_numpy(np.ascontiguousarray(item)).permute(2, 0, 1) for item in items]
-    )
+
+    # `image_to_tensor` normalises each element to (3, H, W), handling paths, HWC
+    # arrays and CHW/HWC tensors alike -- the last of which is what Detection.crop
+    # returns.
+    tensors = [image_to_tensor(item, "RGB") for item in items]
+
+    target_hw = tensors[0].shape[-2:]
+    if any(t.shape[-2:] != target_hw for t in tensors):
+        tensors = [
+            t
+            if t.shape[-2:] == target_hw
+            else TF.resize(t, list(target_hw), antialias=True).to(t.dtype)
+            for t in tensors
+        ]
+
+    return torch.stack([t.contiguous() for t in tensors])
 
 
 def images_to_np(

--- a/exordium/video/deep/__init__.py
+++ b/exordium/video/deep/__init__.py
@@ -4,6 +4,7 @@ from exordium.video.deep.clip import ClipWrapper
 from exordium.video.deep.dinov2 import DINOv2Wrapper
 from exordium.video.deep.emotieffnet import EmotiEffNetWrapper
 from exordium.video.deep.fabnet import FabNetWrapper
+from exordium.video.deep.farl import FarlWrapper
 from exordium.video.deep.marlin import MarlinWrapper
 from exordium.video.deep.swint import (
     SwinTransformer,
@@ -20,6 +21,7 @@ __all__ = [
     "DINOv2Wrapper",
     "EmotiEffNetWrapper",
     "FabNetWrapper",
+    "FarlWrapper",
     "MarlinWrapper",
     "SwinTransformer",
     "SwinTWrapper",

--- a/exordium/video/deep/emotieffnet.py
+++ b/exordium/video/deep/emotieffnet.py
@@ -4,10 +4,13 @@ Wraps the EmotiEffNet models from the EmotiEffLib project for penultimate-layer
 feature extraction.  Models are EfficientNet backbones (B0 or B2) pre-trained on
 VGGFace2 and fine-tuned on AffectNet for facial expression recognition.
 
-Weights are downloaded on first use from the EmotiEffLib GitHub repository and
-cached locally.  The final classification head is replaced with an identity
-layer so that :meth:`inference` returns penultimate features rather than class
-logits.
+Weights are downloaded on first use and cached locally.  They are served from the
+``fodorad/exordium-weights`` mirror, falling back to the original EmotiEffLib GitHub
+release if the mirror cannot be reached, so neither source is a single point of failure.
+The checkpoints are the unmodified EmotiEffLib files (Apache-2.0); see the References
+below for the original project and authors.  The final classification head is replaced
+with an identity layer so that :meth:`inference` returns penultimate features rather
+than class logits.
 
 The checkpoints from EmotiEffLib are full pickled models saved with an older
 ``timm`` version (0.9.x).  To avoid compatibility issues with newer ``timm``
@@ -28,7 +31,7 @@ import torch.nn as nn
 import torchvision.transforms.functional as TF
 
 from exordium import WEIGHT_DIR
-from exordium.utils.ckpt import download_file
+from exordium.utils.ckpt import download_weight
 from exordium.video.deep.base import _IMAGENET_MEAN, _IMAGENET_STD, VisualModelWrapper
 
 logger = logging.getLogger(__name__)
@@ -38,7 +41,11 @@ _WEIGHT_URL = (
     "https://github.com/sb-ai-lab/EmotiEffLib/blob/main/"
     "models/affectnet_emotions/{name}.pt?raw=true"
 )
-"""URL template for downloading EmotiEffNet checkpoint files."""
+"""Original EmotiEffLib download URL, kept as the fallback behind the mirror.
+
+GitHub rate-limits unauthenticated requests from shared CI address ranges, which is why
+the mirror is tried first rather than this.
+"""
 
 _MODELS: dict[str, dict] = {
     "enet_b0_8_best_vgaf": {
@@ -166,9 +173,11 @@ class EmotiEffNetWrapper(VisualModelWrapper):
             num_classes=cfg["num_classes"],
         )
         if pretrained:
-            weight_dir = WEIGHT_DIR / "emotieffnet"
-            local_path = weight_dir / f"{model_name}.pt"
-            download_file(_WEIGHT_URL.format(name=model_name), local_path)
+            local_path = download_weight(
+                f"{model_name}.pt",
+                WEIGHT_DIR / "emotieffnet",
+                upstream_url=_WEIGHT_URL.format(name=model_name),
+            )
             model.load_state_dict(_load_state_dict_from_pickle(str(local_path)))
         else:
             logger.info("Building EmotiEffNet architecture with random weights (no checkpoint).")

--- a/exordium/video/deep/farl.py
+++ b/exordium/video/deep/farl.py
@@ -1,0 +1,335 @@
+"""FaRL universal facial representation wrapper.
+
+Wraps the FaRL (Facial Representation Learning) vision encoder for frame-wise
+feature extraction.  FaRL is a CLIP ViT-B/16 further pre-trained on LAION-Face
+(20M face image-text pairs) with combined image-text contrastive learning and
+masked image modelling, yielding a *general-purpose* face representation that
+transfers well to attribute prediction, parsing, alignment and expression tasks.
+
+Unlike :class:`~exordium.video.deep.emotieffnet.EmotiEffNetWrapper` — which is
+fine-tuned for the 8 AffectNet expression classes and therefore discards cues
+irrelevant to that head — FaRL is trained without task supervision.  This makes
+it the better complement for traits that are not pure expression (apparent
+personality, sentiment), and the two are designed to be concatenated.
+
+Weights ship as a raw OpenAI-CLIP ``state_dict``.  This wrapper converts it to
+the HuggingFace ``CLIPVisionModelWithProjection`` layout on load, so no
+``openai-clip`` dependency is needed: the fused ``in_proj_weight`` attention
+matrices are split into separate q/k/v projections and the OpenAI module names
+are remapped.  FaRL's masked-image-modelling heads (``lm_transformer``,
+``lm_head``, ``mask_token``) exist only for pre-training and are discarded.
+
+License:
+    FaRL code and weights are released under the MIT License by Microsoft.
+
+References:
+    * https://github.com/FacePerceiver/FaRL
+    * Zheng et al. (2022), *General Facial Representation Learning in a
+      Visual-Linguistic Manner*, CVPR (Oral).  https://arxiv.org/abs/2112.03109
+"""
+
+import logging
+from collections.abc import Sequence
+from typing import Any
+
+import torch
+import torch.nn as nn
+import torchvision.transforms.functional as TF
+from transformers import CLIPVisionConfig, CLIPVisionModelWithProjection
+
+from exordium import WEIGHT_DIR
+from exordium.utils.ckpt import download_weight
+from exordium.video.deep.base import VisualModelWrapper
+
+logger = logging.getLogger(__name__)
+"""Module-level logger."""
+
+_CLIP_MEAN = [0.48145466, 0.4578275, 0.40821073]
+"""CLIP RGB channel means. FaRL inherits OpenAI CLIP's normalisation."""
+_CLIP_STD = [0.26862954, 0.26130258, 0.27577711]
+"""CLIP RGB channel standard deviations. FaRL inherits OpenAI CLIP's normalisation."""
+
+_WEIGHT_URL = (
+    "https://github.com/FacePerceiver/FaRL/releases/download/pretrained_weights/{name}.pth"
+)
+"""Original FaRL release URL, kept as the fallback behind the mirror.
+
+GitHub rate-limits unauthenticated requests from shared CI address ranges, so the
+``fodorad/exordium-weights`` mirror is tried first.
+"""
+
+_MODELS: dict[str, dict] = {
+    "ep16": {
+        "filename": "FaRL-Base-Patch16-LAIONFace20M-ep16",
+        "epochs": 16,
+    },
+    "ep64": {
+        "filename": "FaRL-Base-Patch16-LAIONFace20M-ep64",
+        "epochs": 64,
+    },
+}
+"""Supported FaRL variants.
+
+Both are ViT-B/16 trained on LAION-Face 20M and differ only in pre-training
+length.  ``ep16`` is the checkpoint used in the CVPR paper; ``ep64`` is the
+longer-trained release the authors recommend for downstream transfer.
+"""
+
+_DEFAULT_MODEL = "ep64"
+"""Default FaRL variant — the longer-trained checkpoint."""
+
+_IMG_SIZE = 224
+"""FaRL pre-training resolution (ViT-B/16 → 14x14 patches + CLS)."""
+
+_FEATURE_DIM = 512
+"""Dimension of the projected FaRL image embedding."""
+
+_HIDDEN_SIZE = 768
+"""ViT-B hidden width, before the CLIP projection."""
+
+_NUM_LAYERS = 12
+"""ViT-B transformer depth."""
+
+_NUM_HEADS = 12
+"""ViT-B attention head count."""
+
+
+def _vision_config() -> CLIPVisionConfig:
+    """Build the CLIP ViT-B/16 vision config that FaRL's weights expect.
+
+    Returns:
+        A :class:`~transformers.CLIPVisionConfig` matching FaRL's architecture.
+
+    """
+    return CLIPVisionConfig(
+        hidden_size=_HIDDEN_SIZE,
+        intermediate_size=_HIDDEN_SIZE * 4,
+        num_hidden_layers=_NUM_LAYERS,
+        num_attention_heads=_NUM_HEADS,
+        image_size=_IMG_SIZE,
+        patch_size=16,
+        projection_dim=_FEATURE_DIM,
+    )
+
+
+def _build_vision_tower() -> Any:
+    """Instantiate the CLIP ViT-B/16 vision tower FaRL's weights expect.
+
+    Returns ``Any`` for the same reason
+    :func:`~exordium.utils.ckpt.build_hf_model` does: ``transformers`` wraps
+    ``PreTrainedModel.to`` in a decorator whose signature static analysis
+    misreads, so a precisely-typed handle makes an ordinary device move look like
+    a type error.
+
+    Returns:
+        A randomly-initialised :class:`~transformers.CLIPVisionModelWithProjection`.
+
+    """
+    return CLIPVisionModelWithProjection(_vision_config())
+
+
+def _convert_openai_to_hf(state_dict: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+    """Convert a FaRL (OpenAI-CLIP) vision state_dict to the HuggingFace layout.
+
+    Three things differ between the two conventions:
+
+    * **Module names** — OpenAI uses ``visual.transformer.resblocks.N.*``;
+      HuggingFace uses ``vision_model.encoder.layers.N.*``.
+    * **Attention packing** — OpenAI stores one fused ``in_proj_weight`` of shape
+      ``(3*D, D)``; HuggingFace expects separate ``q_proj`` / ``k_proj`` /
+      ``v_proj``.  The fused matrix is split in q, k, v order.
+    * **Projection orientation** — OpenAI's ``visual.proj`` is ``(D, P)`` and is
+      applied as ``x @ proj``; HuggingFace's ``visual_projection`` is an
+      ``nn.Linear`` holding ``(P, D)``, so it must be transposed.
+
+    Keys under ``visual.lm_*`` / ``visual.ln_lm`` / ``visual.mask_token`` belong
+    to FaRL's masked-image-modelling pre-training head and are dropped — they
+    have no counterpart in the encoder used for feature extraction.
+
+    Args:
+        state_dict: The ``"state_dict"`` entry of a FaRL ``.pth`` checkpoint.
+
+    Returns:
+        A state_dict loadable into
+        :class:`~transformers.CLIPVisionModelWithProjection` with no missing or
+        unexpected keys.
+
+    """
+    out: dict[str, torch.Tensor] = {
+        "vision_model.embeddings.class_embedding": state_dict["visual.class_embedding"],
+        "vision_model.embeddings.patch_embedding.weight": state_dict["visual.conv1.weight"],
+        "vision_model.embeddings.position_embedding.weight": state_dict[
+            "visual.positional_embedding"
+        ],
+        "vision_model.pre_layrnorm.weight": state_dict["visual.ln_pre.weight"],
+        "vision_model.pre_layrnorm.bias": state_dict["visual.ln_pre.bias"],
+        "vision_model.post_layernorm.weight": state_dict["visual.ln_post.weight"],
+        "vision_model.post_layernorm.bias": state_dict["visual.ln_post.bias"],
+        # (D, P) applied as x @ proj  ->  nn.Linear weight of shape (P, D).
+        "visual_projection.weight": state_dict["visual.proj"].t().contiguous(),
+    }
+
+    for i in range(_NUM_LAYERS):
+        src = f"visual.transformer.resblocks.{i}."
+        dst = f"vision_model.encoder.layers.{i}."
+
+        # Split the fused QKV projection: rows are ordered [q; k; v].
+        weight = state_dict[f"{src}attn.in_proj_weight"]
+        bias = state_dict[f"{src}attn.in_proj_bias"]
+        dim = weight.shape[0] // 3
+        for idx, name in enumerate(("q", "k", "v")):
+            lo, hi = idx * dim, (idx + 1) * dim
+            out[f"{dst}self_attn.{name}_proj.weight"] = weight[lo:hi]
+            out[f"{dst}self_attn.{name}_proj.bias"] = bias[lo:hi]
+
+        out[f"{dst}self_attn.out_proj.weight"] = state_dict[f"{src}attn.out_proj.weight"]
+        out[f"{dst}self_attn.out_proj.bias"] = state_dict[f"{src}attn.out_proj.bias"]
+        out[f"{dst}layer_norm1.weight"] = state_dict[f"{src}ln_1.weight"]
+        out[f"{dst}layer_norm1.bias"] = state_dict[f"{src}ln_1.bias"]
+        out[f"{dst}layer_norm2.weight"] = state_dict[f"{src}ln_2.weight"]
+        out[f"{dst}layer_norm2.bias"] = state_dict[f"{src}ln_2.bias"]
+        out[f"{dst}mlp.fc1.weight"] = state_dict[f"{src}mlp.c_fc.weight"]
+        out[f"{dst}mlp.fc1.bias"] = state_dict[f"{src}mlp.c_fc.bias"]
+        out[f"{dst}mlp.fc2.weight"] = state_dict[f"{src}mlp.c_proj.weight"]
+        out[f"{dst}mlp.fc2.bias"] = state_dict[f"{src}mlp.c_proj.bias"]
+
+    return out
+
+
+class FarlWrapper(VisualModelWrapper):
+    """FaRL universal face representation extractor.
+
+    Extracts L2-normalised 512-d embeddings from face crops using the FaRL
+    ViT-B/16 vision encoder.  Because FaRL is trained with language supervision
+    on face images rather than fine-tuned on an expression label set, its
+    features stay useful for tasks an expression classifier would throw away —
+    apparent personality, sentiment, and attributes.
+
+    Model weights are downloaded automatically on first use from the official
+    FaRL GitHub release (MIT licensed) and cached under ``WEIGHT_DIR``.
+
+    Supported variants:
+
+    +------------------+--------+----------+
+    | ``model_name``   | Epochs | Feat dim |
+    +==================+========+==========+
+    | ``ep16``         | 16     | 512      |
+    +------------------+--------+----------+
+    | ``ep64``         | 64     | 512      |
+    +------------------+--------+----------+
+
+    Args:
+        model_name: FaRL variant — ``"ep16"`` (paper checkpoint) or ``"ep64"``
+            (longer pre-training, better transfer).  Defaults to ``"ep64"``.
+        device_id: GPU device index.  ``None`` or negative uses CPU.
+        pretrained: If ``False``, build the architecture with random weights and
+            download nothing.  Shapes and call paths are identical, but the
+            features are meaningless — intended for tests and offline use.
+
+    Raises:
+        ValueError: If ``model_name`` is not one of the supported variants.
+
+    Example::
+
+        from exordium.video.deep.farl import FarlWrapper
+
+        model = FarlWrapper(model_name="ep64", device_id=0)
+
+        # single face crop -> (1, 512)
+        features = model(face_crop)
+
+        # face track -> one embedding per non-interpolated detection
+        result = model.track_to_feature(track)
+        # result["frame_ids"]: (N,)      result["features"]: (N, 512)
+
+    """
+
+    def __init__(
+        self,
+        model_name: str = _DEFAULT_MODEL,
+        device_id: int | None = None,
+        pretrained: bool = True,
+    ) -> None:
+        if model_name not in _MODELS:
+            raise ValueError(f"Invalid model_name: {model_name!r}. Choose from {sorted(_MODELS)}.")
+        super().__init__(device_id)
+
+        self.feature_dim: int = _FEATURE_DIM
+        self.img_size: int = _IMG_SIZE
+
+        # Built from an explicit config rather than a Hub id: FaRL ships raw OpenAI
+        # CLIP weights, so there is no HF repo to pull an architecture from.
+        model = _build_vision_tower()
+        if pretrained:
+            filename = _MODELS[model_name]["filename"]
+            local_path = download_weight(
+                f"{filename}.pth",
+                WEIGHT_DIR / "farl",
+                upstream_url=_WEIGHT_URL.format(name=filename),
+            )
+            # The release checkpoint holds only tensors, so it loads under the safe
+            # weights_only reader — no arbitrary unpickling.
+            checkpoint = torch.load(str(local_path), map_location="cpu", weights_only=True)
+            model.load_state_dict(_convert_openai_to_hf(checkpoint["state_dict"]))
+        else:
+            logger.info("Building FaRL architecture with random weights (no checkpoint).")
+
+        model.to(self.device)
+        model.eval()
+        self.model: nn.Module = model
+
+        self._mean = torch.tensor(_CLIP_MEAN, dtype=torch.float32, device=self.device).view(
+            1, 3, 1, 1
+        )
+        self._std = torch.tensor(_CLIP_STD, dtype=torch.float32, device=self.device).view(
+            1, 3, 1, 1
+        )
+
+        logger.info(
+            "FaRL (%s) loaded to %s  —  img_size=%d, feature_dim=%d",
+            model_name,
+            self.device,
+            self.img_size,
+            self.feature_dim,
+        )
+
+    def preprocess(self, frames: torch.Tensor | Sequence) -> torch.Tensor:
+        """Resize and normalise face crops for FaRL.
+
+        Applies bicubic resize to 224x224 and CLIP mean/std normalisation
+        (FaRL inherits OpenAI CLIP's constants, *not* ImageNet's).
+
+        Args:
+            frames: Any input supported by
+                :meth:`~exordium.video.deep.base.VisualModelWrapper._to_uint8_tensor`.
+
+        Returns:
+            Float tensor of shape ``(B, 3, 224, 224)`` on ``self.device``.
+
+        """
+        x = self._to_uint8_tensor(frames).to(self.device)
+        x = TF.resize(
+            x,
+            [self.img_size, self.img_size],
+            interpolation=TF.InterpolationMode.BICUBIC,
+            antialias=True,
+        )
+        x = x.float().div(255)
+        return (x - self._mean) / self._std
+
+    def inference(self, tensor: torch.Tensor) -> torch.Tensor:
+        """FaRL vision encoder forward pass.
+
+        Runs the ViT, projects the pooled output into the shared image-text
+        embedding space, and L2-normalises the result.
+
+        Args:
+            tensor: Preprocessed face tensor of shape ``(B, 3, 224, 224)`` on
+                ``self.device``.
+
+        Returns:
+            L2-normalised feature tensor of shape ``(B, 512)``.
+
+        """
+        embeds = self.model(pixel_values=tensor).image_embeds  # (B, 512)
+        return embeds / embeds.norm(dim=-1, keepdim=True)

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -6,12 +6,7 @@ import logging
 import pathlib
 import types
 import unittest
-import urllib.request
 from collections.abc import Iterator
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from http.client import HTTPResponse
 
 FIXTURES_ROOT = pathlib.Path(__file__).parent
 
@@ -133,16 +128,6 @@ class ModelTestCase(unittest.TestCase):
             except AttributeError:
                 pass
         free_torch_memory()
-
-
-def head_ok(url: str, timeout: int = 15) -> bool:
-    """Return True if a HEAD request to *url* returns HTTP 2xx or 3xx."""
-    req = urllib.request.Request(url, method="HEAD")
-    try:
-        resp: HTTPResponse = urllib.request.urlopen(req, timeout=timeout)
-        return resp.status < 400
-    except Exception:
-        return False
 
 
 def hf_repo_exists(repo_id: str, timeout: int = 15) -> bool:

--- a/tests/utils/test_weight_availability.py
+++ b/tests/utils/test_weight_availability.py
@@ -30,6 +30,13 @@ MIRRORED_WEIGHTS = [
     "adaface_ir50.safetensors",
     "adaface_ir101.safetensors",
     "emotion2vec_plus_seed.pt",
+    "enet_b0_8_best_vgaf.pt",
+    "enet_b0_8_best_afew.pt",
+    "enet_b0_8_va_mtl.pt",
+    "enet_b2_8.pt",
+    "enet_b2_7.pt",
+    "FaRL-Base-Patch16-LAIONFace20M-ep16.pth",
+    "FaRL-Base-Patch16-LAIONFace20M-ep64.pth",
 ]
 """Every file the wrappers fetch from the exordium mirror."""
 

--- a/tests/video/core/test_io.py
+++ b/tests/video/core/test_io.py
@@ -134,6 +134,37 @@ class TestToUint8Tensor(unittest.TestCase):
         out = to_uint8_tensor(arrays)
         self.assertEqual(out.shape, (3, 3, 40, 40))
 
+    def test_from_list_of_chw_tensors(self):
+        # Detection.crop() returns (3, H, W) torch tensors, so a face track is a
+        # list of these -- not of HWC arrays.
+        crops = [torch.zeros(3, 40, 40, dtype=torch.uint8) for _ in range(3)]
+        out = to_uint8_tensor(crops)
+        self.assertEqual(out.shape, (3, 3, 40, 40))
+
+    def test_from_list_of_hwc_tensors(self):
+        crops = [torch.zeros(40, 40, 3, dtype=torch.uint8) for _ in range(3)]
+        out = to_uint8_tensor(crops)
+        self.assertEqual(out.shape, (3, 3, 40, 40))
+
+    def test_ragged_tensor_crops_are_resized_to_the_first(self):
+        # A tracked face box drifts frame to frame, so its crops differ in size.
+        crops = [
+            torch.zeros(3, 50, 50, dtype=torch.uint8),
+            torch.zeros(3, 64, 64, dtype=torch.uint8),
+            torch.zeros(3, 37, 41, dtype=torch.uint8),  # edge-clipped: non-square
+        ]
+        out = to_uint8_tensor(crops)
+        self.assertEqual(out.shape, (3, 3, 50, 50))
+        self.assertEqual(out.dtype, torch.uint8)
+
+    def test_ragged_numpy_crops_are_resized_to_the_first(self):
+        crops = [
+            np.zeros((50, 50, 3), dtype=np.uint8),
+            np.zeros((64, 70, 3), dtype=np.uint8),
+        ]
+        out = to_uint8_tensor(crops)
+        self.assertEqual(out.shape, (2, 3, 50, 50))
+
     def test_empty_sequence_raises(self):
         with self.assertRaises(ValueError):
             to_uint8_tensor([])

--- a/tests/video/deep/test_emotieffnet.py
+++ b/tests/video/deep/test_emotieffnet.py
@@ -7,6 +7,7 @@ import unittest
 import numpy as np
 import torch
 
+from exordium.utils.ckpt import _HF_REPO_ID
 from exordium.video.deep.emotieffnet import (
     _DEFAULT_MODEL,
     _MODELS,
@@ -18,7 +19,7 @@ from tests.fixtures import (
     PRETRAINED,
     VIDEO_MULTISPEAKER_SHORT,
     ModelTestCase,
-    head_ok,
+    hf_file_exists,
 )
 
 
@@ -96,9 +97,15 @@ class TestEmotiEffNetWrapperB0(ModelTestCase):
 
 
 class TestEmotiEffNetWeightAvailability(unittest.TestCase):
-    def test_emotieffnet_b0_vgaf_url(self):
-        url = "https://github.com/sb-ai-lab/EmotiEffLib/blob/main/models/affectnet_emotions/enet_b0_8_best_vgaf.pt?raw=true"
-        self.assertTrue(head_ok(url), f"Not reachable: {url}")
+    def test_emotieffnet_b0_vgaf_mirrored(self):
+        # Checked against the mirror, not the EmotiEffLib GitHub URL: GitHub rate-limits
+        # unauthenticated requests from shared CI address ranges, so probing it made the
+        # suite fail on a weight that was perfectly healthy. The GitHub URL remains the
+        # runtime fallback; MIRRORED_WEIGHTS covers every variant.
+        self.assertTrue(
+            hf_file_exists(_HF_REPO_ID, "enet_b0_8_best_vgaf.pt"),
+            f"Not reachable: {_HF_REPO_ID}/enet_b0_8_best_vgaf.pt",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/video/deep/test_farl.py
+++ b/tests/video/deep/test_farl.py
@@ -1,0 +1,227 @@
+"""Tests for FarlWrapper visual feature extractor."""
+
+import pathlib
+import tempfile
+import unittest
+
+import numpy as np
+import torch
+
+from exordium.utils.ckpt import _HF_REPO_ID
+from exordium.video.core.detection import DetectionFromTorchTensor, Track
+from exordium.video.deep.farl import (
+    _DEFAULT_MODEL,
+    _FEATURE_DIM,
+    _HIDDEN_SIZE,
+    _MODELS,
+    _NUM_LAYERS,
+    FarlWrapper,
+    _convert_openai_to_hf,
+    _vision_config,
+)
+from tests.fixtures import (
+    IMAGE_EMMA,
+    IMAGE_FACE,
+    PRETRAINED,
+    VIDEO_MULTISPEAKER_SHORT,
+    ModelTestCase,
+    hf_file_exists,
+)
+
+
+def _fake_farl_state_dict() -> dict[str, torch.Tensor]:
+    """Build an OpenAI-CLIP-style FaRL state_dict of the right shapes.
+
+    Values are random; only the *key layout* and *shapes* mirror the real
+    checkpoint, which is what the converter is responsible for handling. The MIM
+    pre-training keys are included so the test proves they are dropped rather
+    than leaking into the encoder.
+    """
+    d = _HIDDEN_SIZE
+    sd: dict[str, torch.Tensor] = {
+        "visual.class_embedding": torch.randn(d),
+        "visual.positional_embedding": torch.randn(197, d),
+        "visual.proj": torch.randn(d, _FEATURE_DIM),
+        "visual.conv1.weight": torch.randn(d, 3, 16, 16),
+        "visual.ln_pre.weight": torch.randn(d),
+        "visual.ln_pre.bias": torch.randn(d),
+        "visual.ln_post.weight": torch.randn(d),
+        "visual.ln_post.bias": torch.randn(d),
+        # Pre-training-only heads: must not survive conversion.
+        "visual.mask_token": torch.randn(d),
+        "visual.ln_lm.weight": torch.randn(d),
+        "visual.lm_head.weight": torch.randn(8192, d),
+        # Text tower: also irrelevant to the vision encoder.
+        "text_projection": torch.randn(d, _FEATURE_DIM),
+        "logit_scale": torch.tensor(4.6),
+    }
+    for i in range(_NUM_LAYERS):
+        p = f"visual.transformer.resblocks.{i}."
+        sd |= {
+            f"{p}attn.in_proj_weight": torch.randn(3 * d, d),
+            f"{p}attn.in_proj_bias": torch.randn(3 * d),
+            f"{p}attn.out_proj.weight": torch.randn(d, d),
+            f"{p}attn.out_proj.bias": torch.randn(d),
+            f"{p}ln_1.weight": torch.randn(d),
+            f"{p}ln_1.bias": torch.randn(d),
+            f"{p}ln_2.weight": torch.randn(d),
+            f"{p}ln_2.bias": torch.randn(d),
+            f"{p}mlp.c_fc.weight": torch.randn(4 * d, d),
+            f"{p}mlp.c_fc.bias": torch.randn(4 * d),
+            f"{p}mlp.c_proj.weight": torch.randn(d, 4 * d),
+            f"{p}mlp.c_proj.bias": torch.randn(d),
+        }
+    return sd
+
+
+def _track(num_frames: int = 6) -> Track:
+    """A short synthetic face track with per-frame boxes of drifting size."""
+    frame = torch.randint(0, 255, (3, 400, 400), dtype=torch.uint8)
+    landmarks = torch.zeros(5, 2, dtype=torch.long)
+    track = Track(track_id=0)
+    for fid in range(num_frames):
+        side = 100 + (fid % 5) * 10
+        x = y = 200 - side // 2
+        track.add(
+            DetectionFromTorchTensor(
+                frame_id=fid,
+                source=frame,
+                score=0.99,
+                bb_xywh=torch.tensor([x, y, side, side], dtype=torch.long),
+                landmarks=landmarks,
+            )
+        )
+    return track
+
+
+class TestFarlConversion(unittest.TestCase):
+    """The OpenAI -> HuggingFace state_dict conversion is the load-bearing logic."""
+
+    def test_converted_dict_loads_with_no_missing_or_unexpected_keys(self):
+        from transformers import CLIPVisionModelWithProjection
+
+        model = CLIPVisionModelWithProjection(_vision_config())
+        missing, unexpected = model.load_state_dict(
+            _convert_openai_to_hf(_fake_farl_state_dict()), strict=False
+        )
+        self.assertEqual(list(missing), [])
+        self.assertEqual(list(unexpected), [])
+
+    def test_pretraining_heads_are_dropped(self):
+        converted = _convert_openai_to_hf(_fake_farl_state_dict())
+        for key in converted:
+            self.assertNotIn("lm_head", key)
+            self.assertNotIn("mask_token", key)
+            self.assertNotIn("text_projection", key)
+
+    def test_fused_qkv_is_split_in_q_k_v_order(self):
+        sd = _fake_farl_state_dict()
+        converted = _convert_openai_to_hf(sd)
+        fused = sd["visual.transformer.resblocks.0.attn.in_proj_weight"]
+        d = _HIDDEN_SIZE
+        torch.testing.assert_close(
+            converted["vision_model.encoder.layers.0.self_attn.q_proj.weight"], fused[:d]
+        )
+        torch.testing.assert_close(
+            converted["vision_model.encoder.layers.0.self_attn.k_proj.weight"], fused[d : 2 * d]
+        )
+        torch.testing.assert_close(
+            converted["vision_model.encoder.layers.0.self_attn.v_proj.weight"], fused[2 * d :]
+        )
+
+    def test_visual_projection_is_transposed(self):
+        sd = _fake_farl_state_dict()
+        converted = _convert_openai_to_hf(sd)
+        # OpenAI stores (D, P) applied as x @ proj; nn.Linear needs (P, D).
+        self.assertEqual(
+            tuple(converted["visual_projection.weight"].shape), (_FEATURE_DIM, _HIDDEN_SIZE)
+        )
+        torch.testing.assert_close(
+            converted["visual_projection.weight"], sd["visual.proj"].t().contiguous()
+        )
+
+    def test_all_layers_are_converted(self):
+        converted = _convert_openai_to_hf(_fake_farl_state_dict())
+        for i in range(_NUM_LAYERS):
+            self.assertIn(f"vision_model.encoder.layers.{i}.self_attn.q_proj.weight", converted)
+        self.assertNotIn(
+            f"vision_model.encoder.layers.{_NUM_LAYERS}.self_attn.q_proj.weight", converted
+        )
+
+
+class TestFarlWrapperInit(unittest.TestCase):
+    def test_invalid_model_name_raises(self):
+        with self.assertRaises(ValueError):
+            FarlWrapper(model_name="nonexistent_model")
+
+    def test_module_constants_consistent(self):
+        self.assertIn(_DEFAULT_MODEL, _MODELS)
+        for cfg in _MODELS.values():
+            self.assertIn("filename", cfg)
+            self.assertIn("epochs", cfg)
+
+
+class TestFarlWrapper(ModelTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = FarlWrapper(model_name=_DEFAULT_MODEL, device_id=None, pretrained=PRETRAINED)
+
+    def test_feature_dim_attribute(self):
+        self.assertEqual(self.model.feature_dim, _FEATURE_DIM)
+
+    def test_from_image_path(self):
+        self.assertEqual(self.model(IMAGE_FACE).shape, (1, _FEATURE_DIM))
+
+    def test_from_numpy_hwc(self):
+        out = self.model(np.random.randint(0, 255, (128, 128, 3), dtype=np.uint8))
+        self.assertEqual(out.shape, (1, _FEATURE_DIM))
+
+    def test_from_batch_tensor(self):
+        out = self.model(torch.randint(0, 255, (4, 3, 224, 224), dtype=torch.uint8))
+        self.assertEqual(out.shape, (4, _FEATURE_DIM))
+
+    def test_preprocess_output_shape(self):
+        out = self.model.preprocess(torch.randint(0, 255, (3, 3, 64, 64), dtype=torch.uint8))
+        self.assertEqual(out.shape, (3, 3, 224, 224))
+
+    def test_output_is_l2_normalised(self):
+        norms = self.model(torch.randint(0, 255, (3, 3, 224, 224), dtype=torch.uint8)).norm(dim=-1)
+        torch.testing.assert_close(norms, torch.ones_like(norms))
+
+    def test_feature_dim_consistent(self):
+        self.assertEqual(self.model(IMAGE_FACE).shape[1], self.model(IMAGE_EMMA).shape[1])
+
+    def test_track_to_feature(self):
+        track = _track(num_frames=6)
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            result = self.model.track_to_feature(
+                track, batch_size=4, output_path=pathlib.Path(tmp_dir) / "farl.st"
+            )
+        self.assertEqual(result["features"].shape, (6, _FEATURE_DIM))
+        self.assertEqual(result["frame_ids"].tolist(), list(range(6)))
+
+    def test_video_to_feature(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            result = self.model.video_to_feature(
+                VIDEO_MULTISPEAKER_SHORT,
+                batch_size=8,
+                output_path=pathlib.Path(tmp_dir) / "farl.st",
+            )
+        self.assertEqual(result["features"].shape[1], _FEATURE_DIM)
+
+
+class TestFarlWeightAvailability(unittest.TestCase):
+    def test_checkpoints_mirrored(self):
+        # Checked against the mirror, not the FaRL GitHub release: GitHub rate-limits
+        # unauthenticated requests from shared CI address ranges, so a healthy weight can
+        # read as missing. The release URL remains the runtime fallback.
+        missing = [
+            cfg["filename"]
+            for cfg in _MODELS.values()
+            if not hf_file_exists(_HF_REPO_ID, f"{cfg['filename']}.pth")
+        ]
+        self.assertEqual(missing, [], f"Missing from {_HF_REPO_ID}: {missing}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds the FaRL universal face representation wrapper and removes the last two GitHub-only weight downloads.

## Why
`test_emotieffnet_b0_vgaf_url` is failing on PR #49 (dev → main). The cause is not a missing weight — GitHub rate-limits unauthenticated requests from shared CI address ranges. `emotieffnet` and `farl` were the only wrappers still downloading from GitHub with no mirror fallback, so this was a live single point of failure for users, not just a flaky test.

## What
- **New:** `FarlWrapper` — CLIP ViT-B/16, LAION-Face 20M, 512-d. Converts the raw OpenAI-CLIP checkpoint to the HuggingFace layout on load, so no `openai-clip` dependency.
- **Fixed:** `download_weight()` gains an `upstream_url` fallback; emotieffnet and farl now go mirror-first, GitHub-fallback.
- **Fixed:** weight-availability tests use `hf_file_exists()`; `head_ok()` is deleted (a HEAD on an LFS `/resolve/` URL hits a presigned S3 link that 403s).
- **New:** `examples/demo_video_deep_face.ipynb`.

## Tests
826 passing, 93% coverage. 17 tests for FaRL — five cover the OpenAI→HF state_dict conversion specifically, since that is where a silent bug would hide: no missing/unexpected keys, pretraining heads dropped, QKV split in q-k-v order, projection transposed, all 12 layers converted.