### PR TITLE
ci(dependabot): open PRs against dev instead of main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,11 @@
+# Dependabot opens its PRs against dev, never main. main only accepts merges from dev
+# (enforced by the only-dev-into-main ruleset), so a PR based on main is blocked on
+# arrival and can never be merged -- which is what happened to #53.
 version: 2
 updates:
   - package-ecosystem: pip
     directory: "/"
+    target-branch: dev
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
@@ -26,6 +30,7 @@ updates:
 
   - package-ecosystem: github-actions
     directory: "/"
+    target-branch: dev
     schedule:
       interval: weekly
     open-pull-requests-limit: 5


### PR DESCRIPTION
Dependabot defaulted to the repo default branch (`main`), but the `only-dev-into-main` ruleset rejects any PR based on `main` — so every dependabot PR arrived permanently blocked (#53, and #44/#45 before it).

`target-branch: dev` on both the pip and github-actions ecosystems routes them through the branch that actually accepts merges. Closing #53, which cannot be rebased onto the new target and will be reopened against `dev` automatically.