### PR TITLE
feat(video): densify sparse track features onto a gap-free frame grid

### DIFF
--- a/exordium/video/core/__init__.py
+++ b/exordium/video/core/__init__.py
@@ -12,6 +12,7 @@ from exordium.video.core.bb import (
     xyxy2full,
     xyxy2xywh,
 )
+from exordium.video.core.densify import densify
 from exordium.video.core.detection import (
     Detection,
     DetectionFactory,
@@ -44,6 +45,7 @@ from exordium.video.core.io import (
 )
 
 __all__ = [
+    "densify",
     "apply_10_crop",
     "center_crop",
     "crop_mid",

--- a/exordium/video/core/densify.py
+++ b/exordium/video/core/densify.py
@@ -1,0 +1,184 @@
+"""Scatter sparse per-detection features onto a dense, regular time grid.
+
+Feature extractors return one vector per *detection*, not per *frame*: a face
+track covers only the frames where the subject was actually detected, so
+:meth:`~exordium.video.deep.base.VisualModelWrapper.track_to_feature` yields
+``(N, D)`` with ``N <= num_frames``. That sparse form is the right default —
+it wastes nothing and stays honest about what was observed.
+
+It is the wrong form for a *temporal model*. A sequence head consuming face,
+audio and text streams needs them on a common, gap-free time axis, so timestep
+*i* means the same instant in every modality. :func:`densify` performs that
+conversion: it scatters the sparse features onto the frame grid, fills the
+frames with no detection with a constant vector, and returns a boolean mask
+saying which timesteps were real.
+
+The mask is the load-bearing part. Zero-filled timesteps are *not* observations
+of a zero-valued face; they are absences, and a model must be told to ignore
+them (attention masking, packed sequences, masked pooling) rather than fitting
+them. A dense tensor without its mask silently teaches the model that "no face
+detected" is a meaningful feature value.
+
+The output contract — ``frame_ids`` / ``features`` / ``mask`` — is deliberately
+identical to the one
+:meth:`~exordium.video.deep.marlin.MarlinWrapper.track_to_feature` already
+produces, so densified frame-wise features and MARLIN's window-wise features
+are interchangeable downstream.
+
+.. note::
+
+   Every **frame-wise** extractor inherits ``densify=`` from
+   :meth:`~exordium.video.deep.base.VisualModelWrapper.track_to_feature` —
+   FaRL, EmotiEffNet, FabNet, CLIP, DINOv2, AdaFace, SwinT, OpenGraphAU and
+   SixDRepNet.
+
+   :class:`~exordium.video.deep.marlin.MarlinWrapper` does **not** take the
+   argument, and does not need it: MARLIN is a *video* model whose timestep is
+   a 16-frame **window**, not a frame, so its ``frame_ids`` are window start
+   indices (``0, 16, 32, ...``). It already emits this exact dense contract
+   natively, zero-filling empty windows. Densifying it would require answering
+   "which frame is window 2?", which has no honest answer — aligning MARLIN to
+   a frame grid means *upsampling* its window features, a different operation.
+"""
+
+import torch
+
+__all__ = ["densify"]
+
+
+def densify(
+    frame_ids: torch.Tensor,
+    features: torch.Tensor,
+    start_frame_id: int = 0,
+    end_frame_id: int | None = None,
+    fill: torch.Tensor | float = 0.0,
+    strict: bool = False,
+) -> dict[str, torch.Tensor]:
+    """Scatter sparse per-detection features onto a dense frame grid.
+
+    Builds the half-open frame range ``[start_frame_id, end_frame_id)``, places
+    each feature at its own frame, and fills the rest with ``fill``.
+
+    Densifying a *window* rather than the whole video keeps this O(window)
+    instead of O(video): a long track through a 10-minute recording can be
+    densified over a 250-frame snippet without materialising the full timeline.
+    Whole-video densification is just the special case
+    ``start_frame_id=0, end_frame_id=num_frames``.
+
+    Args:
+        frame_ids: ``(N,)`` long tensor of frame indices, as returned by
+            ``track_to_feature``. Need not be sorted or contiguous.
+        features: ``(N, D)`` float tensor of per-detection features, row-aligned
+            with ``frame_ids``.
+        start_frame_id: First frame of the output grid, inclusive. Defaults to 0.
+        end_frame_id: One past the last frame of the output grid (exclusive).
+            When ``None``, defaults to ``max(frame_ids) + 1`` — which
+            **undercounts if the video continues past the last detection**, so
+            pass it explicitly whenever the true length is known.
+        fill: Value for frames with no detection. Either a scalar (broadcast
+            across the feature dimension) or a ``(D,)`` tensor. Defaults to 0.0.
+        strict: If True, raise when a frame id falls outside the output range.
+            If False (default), such detections are dropped — a long track
+            legitimately extends past a short window, so clipping is the normal
+            case, not an error.
+
+    Returns:
+        Dict with, where ``T = end_frame_id - start_frame_id``:
+
+        * ``"frame_ids"`` — ``(T,)`` long tensor, ``start_frame_id`` to
+          ``end_frame_id - 1``. Absolute frame indices, not offsets into the
+          window.
+        * ``"features"`` — ``(T, D)`` tensor, ``fill`` where no detection
+          exists. Same dtype as ``features``.
+        * ``"mask"`` — ``(T,)`` bool tensor. ``True`` where a real detection
+          landed on that frame, ``False`` where the value is ``fill``.
+
+    Raises:
+        ValueError: If ``features`` is not 2-D, if ``frame_ids`` and ``features``
+            disagree on length, if ``end_frame_id <= start_frame_id``, if ``fill``
+            is a tensor whose shape is not ``(D,)``, or — when ``strict`` — if any
+            frame id falls outside ``[start_frame_id, end_frame_id)``.
+
+    Example::
+
+        from exordium.video.core.densify import densify
+
+        sparse = model.track_to_feature(track)          # (N, D), N <= num_frames
+        dense = densify(
+            sparse["frame_ids"],
+            sparse["features"],
+            end_frame_id=num_frames,                    # full video
+        )
+        dense["features"]  # (num_frames, D), zeros where no face was detected
+        dense["mask"]      # (num_frames,) bool — feed this to your temporal model
+
+        # A 10-second snippet at 25 fps, without materialising the whole video:
+        window = densify(
+            sparse["frame_ids"], sparse["features"],
+            start_frame_id=100, end_frame_id=350,
+        )
+        window["features"].shape  # (250, D)
+
+    """
+    if features.ndim != 2:
+        raise ValueError(f"features must be 2-D (N, D), got shape {tuple(features.shape)}.")
+    if frame_ids.shape[0] != features.shape[0]:
+        raise ValueError(
+            f"frame_ids and features disagree on length: "
+            f"{frame_ids.shape[0]} ids vs {features.shape[0]} feature rows."
+        )
+
+    feature_dim = features.shape[1]
+
+    if end_frame_id is None:
+        # No explicit end: span up to the last detection. Undercounts a video that
+        # continues past it, which is why the docstring pushes callers to pass it.
+        end_frame_id = int(frame_ids.max()) + 1 if frame_ids.numel() else start_frame_id
+
+    if end_frame_id < start_frame_id:
+        raise ValueError(
+            f"end_frame_id ({end_frame_id}) must be >= start_frame_id ({start_frame_id})."
+        )
+
+    num_timesteps = end_frame_id - start_frame_id
+
+    if isinstance(fill, torch.Tensor):
+        if fill.shape != (feature_dim,):
+            raise ValueError(
+                f"fill tensor must have shape ({feature_dim},) to match the feature "
+                f"dimension, got {tuple(fill.shape)}."
+            )
+        dense = fill.to(dtype=features.dtype, device=features.device).expand(
+            num_timesteps, feature_dim
+        )
+        dense = dense.clone()  # expand() gives a read-only view; scatter needs to write.
+    else:
+        dense = torch.full(
+            (num_timesteps, feature_dim),
+            float(fill),
+            dtype=features.dtype,
+            device=features.device,
+        )
+
+    mask = torch.zeros(num_timesteps, dtype=torch.bool, device=features.device)
+
+    in_range = (frame_ids >= start_frame_id) & (frame_ids < end_frame_id)
+    if strict and not bool(in_range.all()):
+        out_of_range = frame_ids[~in_range]
+        raise ValueError(
+            f"{out_of_range.numel()} frame id(s) outside "
+            f"[{start_frame_id}, {end_frame_id}), e.g. {out_of_range[:5].tolist()}."
+        )
+
+    # Absolute frame ids -> offsets into the window.
+    positions = frame_ids[in_range].to(device=features.device) - start_frame_id
+    dense[positions] = features[in_range.to(features.device)]
+    mask[positions] = True
+
+    return {
+        "frame_ids": torch.arange(
+            start_frame_id, end_frame_id, dtype=torch.long, device=features.device
+        ),
+        "features": dense,
+        "mask": mask,
+    }

--- a/exordium/video/deep/base.py
+++ b/exordium/video/deep/base.py
@@ -9,6 +9,7 @@ from tqdm import tqdm
 
 from exordium.utils.decorator import load_or_create
 from exordium.utils.device import get_torch_device
+from exordium.video.core.densify import densify as densify_features
 from exordium.video.core.detection import Track
 from exordium.video.core.io import Video, batch_iterator, to_uint8_tensor
 
@@ -185,21 +186,53 @@ class VisualModelWrapper(ABC):
         self,
         track: Track,
         batch_size: int = 30,
+        densify: bool = False,
+        start_frame_id: int = 0,
+        end_frame_id: int | None = None,
+        fill: torch.Tensor | float = 0.0,
         **_kwargs,
     ) -> dict[str, torch.Tensor]:
         """Extract features from all non-interpolated detections in a track.
 
+        By default the output is **sparse**: one feature row per detection, so
+        ``N <= num_frames`` when the subject was not detected on every frame.
+        That is the honest default — it records only what was observed.
+
+        Set ``densify=True`` to scatter those features onto a gap-free frame
+        grid instead, which is what a temporal model needs to keep the face
+        stream aligned with audio and text. Frames with no detection are filled
+        with ``fill`` and flagged ``False`` in the returned ``mask``.
+
         Results are cached as a safetensors file: pass ``output_path`` and
-        ``overwrite`` via ``_kwargs`` to control caching behaviour.
+        ``overwrite`` via ``_kwargs`` to control caching behaviour. Sparse and
+        dense results differ, so give them **different** ``output_path``s.
 
         Args:
             track: Track containing a sequence of Detection objects.
             batch_size: Detections to process per batch. Defaults to 30.
+            densify: If True, return a dense grid plus a validity mask. See
+                :func:`~exordium.video.core.densify.densify`.
+            start_frame_id: First frame of the dense grid, inclusive. Ignored
+                unless ``densify``. Defaults to 0.
+            end_frame_id: One past the last frame of the dense grid (exclusive).
+                Ignored unless ``densify``. When ``None``, defaults to the last
+                detected frame + 1, which **undercounts if the video continues
+                past the last detection** — pass the video's frame count
+                explicitly whenever it is known.
+            fill: Value for frames with no detection — either a scalar or a
+                ``(D,)`` tensor. Ignored unless ``densify``. Defaults to 0.0.
             **_kwargs: Forwarded to ``load_or_create``.
 
         Returns:
-            Dict with keys ``"frame_ids"`` (``(N,)`` long tensor) and
-            ``"features"`` (``(N, D)`` float tensor), both on CPU.
+            When ``densify=False`` (default), a dict with ``"frame_ids"``
+            (``(N,)`` long) and ``"features"`` (``(N, D)`` float), both on CPU.
+
+            When ``densify=True``, a dict with ``"frame_ids"`` (``(T,)`` long,
+            contiguous), ``"features"`` (``(T, D)``, ``fill`` where undetected)
+            and ``"mask"`` (``(T,)`` bool, True where a detection existed) —
+            the same contract
+            :meth:`~exordium.video.deep.marlin.MarlinWrapper.track_to_feature`
+            returns.
 
         """
         ids: list[int] = []
@@ -211,10 +244,27 @@ class VisualModelWrapper(ABC):
             ids += [d.frame_id for d in subset]
             features.append(self([d.crop(square=True, extra_space=1.5) for d in subset]).cpu())
 
-        return {
-            "frame_ids": torch.tensor(ids, dtype=torch.long),
-            "features": torch.cat(features, dim=0),
-        }
+        frame_ids = torch.tensor(ids, dtype=torch.long)
+        # An empty track yields no batches, so there is nothing to concatenate. The
+        # feature width is still needed to build a well-formed (0, D) tensor, and it
+        # is only knowable by asking the model — not every wrapper exposes it as an
+        # attribute. One forward pass on a dummy crop is a cheap price for an edge case.
+        if features:
+            stacked = torch.cat(features, dim=0)
+        else:
+            probe = self(torch.zeros(1, 3, 224, 224, dtype=torch.uint8)).cpu()
+            stacked = probe.new_zeros((0, probe.shape[-1]))
+
+        if not densify:
+            return {"frame_ids": frame_ids, "features": stacked}
+
+        return densify_features(
+            frame_ids,
+            stacked,
+            start_frame_id=start_frame_id,
+            end_frame_id=end_frame_id,
+            fill=fill,
+        )
 
     @load_or_create("st")
     def video_to_feature(

--- a/tests/video/core/test_densify.py
+++ b/tests/video/core/test_densify.py
@@ -1,0 +1,204 @@
+"""Tests for scattering sparse per-detection features onto a dense frame grid."""
+
+import unittest
+
+import torch
+
+from exordium.video.core.densify import densify
+
+
+def _sparse(frame_ids: list[int], dim: int = 4) -> tuple[torch.Tensor, torch.Tensor]:
+    """Build a sparse (frame_ids, features) pair whose rows are identifiable.
+
+    Row *i* is filled with the value ``frame_ids[i]``, so a test can assert a
+    feature landed on the right timestep by reading the value back.
+    """
+    ids = torch.tensor(frame_ids, dtype=torch.long)
+    features = torch.stack([torch.full((dim,), float(f)) for f in frame_ids])
+    return ids, features
+
+
+class TestDensifyShapeAndContract(unittest.TestCase):
+    """The output must match MARLIN's frame_ids/features/mask contract."""
+
+    def test_returns_the_three_contract_keys(self):
+        ids, feats = _sparse([0, 2])
+        out = densify(ids, feats, end_frame_id=4)
+        self.assertEqual(set(out), {"frame_ids", "features", "mask"})
+
+    def test_dense_shapes_follow_the_window(self):
+        ids, feats = _sparse([1, 3])
+        out = densify(ids, feats, start_frame_id=0, end_frame_id=10)
+        self.assertEqual(out["features"].shape, (10, 4))
+        self.assertEqual(out["mask"].shape, (10,))
+        self.assertEqual(out["frame_ids"].shape, (10,))
+
+    def test_frame_ids_are_absolute_not_window_offsets(self):
+        # A window starting at 100 must report frames 100..104, not 0..4 — otherwise
+        # the caller cannot align the window back to the source video.
+        ids, feats = _sparse([101])
+        out = densify(ids, feats, start_frame_id=100, end_frame_id=105)
+        self.assertEqual(out["frame_ids"].tolist(), [100, 101, 102, 103, 104])
+
+    def test_mask_dtype_is_bool(self):
+        ids, feats = _sparse([0])
+        self.assertEqual(densify(ids, feats, end_frame_id=2)["mask"].dtype, torch.bool)
+
+    def test_feature_dtype_is_preserved(self):
+        ids = torch.tensor([0], dtype=torch.long)
+        feats = torch.ones(1, 4, dtype=torch.float64)
+        self.assertEqual(densify(ids, feats, end_frame_id=3)["features"].dtype, torch.float64)
+
+
+class TestDensifyPlacement(unittest.TestCase):
+    """Features must land on their own frame, and nowhere else."""
+
+    def test_features_land_on_their_own_frame(self):
+        ids, feats = _sparse([0, 2, 5])
+        out = densify(ids, feats, end_frame_id=6)
+        for frame_id in (0, 2, 5):
+            self.assertTrue(
+                torch.equal(out["features"][frame_id], torch.full((4,), float(frame_id)))
+            )
+
+    def test_gaps_are_zero_filled_and_masked_false(self):
+        ids, feats = _sparse([0, 2])
+        out = densify(ids, feats, end_frame_id=4)
+        self.assertEqual(out["mask"].tolist(), [True, False, True, False])
+        for gap in (1, 3):
+            self.assertTrue(torch.equal(out["features"][gap], torch.zeros(4)))
+
+    def test_unsorted_frame_ids_still_land_correctly(self):
+        # track_to_feature batches detections, so ordering is not guaranteed.
+        ids, feats = _sparse([5, 0, 2])
+        out = densify(ids, feats, end_frame_id=6)
+        self.assertEqual(out["mask"].tolist(), [True, False, True, False, False, True])
+        self.assertTrue(torch.equal(out["features"][5], torch.full((4,), 5.0)))
+
+    def test_offset_window_places_features_relative_to_start(self):
+        ids, feats = _sparse([102])
+        out = densify(ids, feats, start_frame_id=100, end_frame_id=104)
+        # Frame 102 is offset 2 within the window.
+        self.assertEqual(out["mask"].tolist(), [False, False, True, False])
+        self.assertTrue(torch.equal(out["features"][2], torch.full((4,), 102.0)))
+
+    def test_fully_dense_track_masks_everything_true(self):
+        ids, feats = _sparse([0, 1, 2])
+        out = densify(ids, feats, end_frame_id=3)
+        self.assertTrue(bool(out["mask"].all()))
+        self.assertTrue(torch.equal(out["features"], feats))
+
+
+class TestDensifyWindowClipping(unittest.TestCase):
+    """A long track legitimately overruns a short window."""
+
+    def test_detections_outside_the_window_are_dropped(self):
+        ids, feats = _sparse([0, 5, 10])
+        out = densify(ids, feats, start_frame_id=4, end_frame_id=7)
+        self.assertEqual(out["features"].shape, (3, 4))
+        self.assertEqual(out["mask"].tolist(), [False, True, False])  # only frame 5 survives
+        self.assertTrue(torch.equal(out["features"][1], torch.full((4,), 5.0)))
+
+    def test_window_entirely_outside_the_track_is_all_fill(self):
+        ids, feats = _sparse([0, 1])
+        out = densify(ids, feats, start_frame_id=50, end_frame_id=53)
+        self.assertFalse(bool(out["mask"].any()))
+        self.assertTrue(torch.equal(out["features"], torch.zeros(3, 4)))
+
+    def test_end_frame_id_is_exclusive(self):
+        # Half-open [start, end): a detection exactly at end_frame_id is outside.
+        ids, feats = _sparse([3])
+        out = densify(ids, feats, start_frame_id=0, end_frame_id=3)
+        self.assertEqual(out["features"].shape[0], 3)
+        self.assertFalse(bool(out["mask"].any()))
+
+    def test_strict_raises_on_out_of_range_frame_id(self):
+        ids, feats = _sparse([0, 99])
+        with self.assertRaises(ValueError):
+            densify(ids, feats, end_frame_id=10, strict=True)
+
+    def test_strict_passes_when_all_ids_fit(self):
+        ids, feats = _sparse([0, 2])
+        out = densify(ids, feats, end_frame_id=10, strict=True)
+        self.assertEqual(int(out["mask"].sum()), 2)
+
+
+class TestDensifyFill(unittest.TestCase):
+    """The fill value marks absence; it must be controllable."""
+
+    def test_scalar_fill_is_broadcast(self):
+        ids, feats = _sparse([1])
+        out = densify(ids, feats, end_frame_id=3, fill=-1.0)
+        self.assertTrue(torch.equal(out["features"][0], torch.full((4,), -1.0)))
+        self.assertTrue(torch.equal(out["features"][2], torch.full((4,), -1.0)))
+
+    def test_vector_fill_is_used_per_gap(self):
+        ids, feats = _sparse([1])
+        fill = torch.tensor([1.0, 2.0, 3.0, 4.0])
+        out = densify(ids, feats, end_frame_id=3, fill=fill)
+        self.assertTrue(torch.equal(out["features"][0], fill))
+        self.assertTrue(torch.equal(out["features"][2], fill))
+
+    def test_fill_does_not_overwrite_real_features(self):
+        ids, feats = _sparse([1])
+        out = densify(ids, feats, end_frame_id=3, fill=-1.0)
+        self.assertTrue(torch.equal(out["features"][1], torch.full((4,), 1.0)))
+
+    def test_vector_fill_rows_are_independent(self):
+        # expand() returns a read-only broadcast view; if it were not cloned, writing
+        # one row would write them all. Prove the rows are genuinely separate.
+        ids, feats = _sparse([0])
+        out = densify(ids, feats, end_frame_id=3, fill=torch.zeros(4))
+        out["features"][1] = 7.0
+        self.assertTrue(torch.equal(out["features"][2], torch.zeros(4)))
+
+    def test_wrong_shape_fill_tensor_raises(self):
+        ids, feats = _sparse([0], dim=4)
+        with self.assertRaises(ValueError):
+            densify(ids, feats, end_frame_id=3, fill=torch.zeros(7))
+
+
+class TestDensifyEdgeCases(unittest.TestCase):
+    def test_empty_track_yields_all_fill_and_empty_mask(self):
+        ids = torch.tensor([], dtype=torch.long)
+        feats = torch.zeros((0, 4))
+        out = densify(ids, feats, end_frame_id=5)
+        self.assertEqual(out["features"].shape, (5, 4))
+        self.assertFalse(bool(out["mask"].any()))
+
+    def test_empty_track_without_end_frame_id_yields_empty_grid(self):
+        ids = torch.tensor([], dtype=torch.long)
+        feats = torch.zeros((0, 4))
+        out = densify(ids, feats)
+        self.assertEqual(out["features"].shape, (0, 4))
+
+    def test_end_frame_id_defaults_to_last_detection_plus_one(self):
+        ids, feats = _sparse([0, 3])
+        out = densify(ids, feats)
+        self.assertEqual(out["features"].shape[0], 4)
+        self.assertEqual(out["mask"].tolist(), [True, False, False, True])
+
+    def test_zero_length_window_is_allowed(self):
+        ids, feats = _sparse([0])
+        out = densify(ids, feats, start_frame_id=2, end_frame_id=2)
+        self.assertEqual(out["features"].shape, (0, 4))
+        self.assertEqual(out["mask"].shape, (0,))
+
+    def test_end_before_start_raises(self):
+        ids, feats = _sparse([0])
+        with self.assertRaises(ValueError):
+            densify(ids, feats, start_frame_id=5, end_frame_id=2)
+
+    def test_non_2d_features_raises(self):
+        ids = torch.tensor([0], dtype=torch.long)
+        with self.assertRaises(ValueError):
+            densify(ids, torch.zeros(3), end_frame_id=2)
+
+    def test_length_mismatch_raises(self):
+        ids = torch.tensor([0, 1], dtype=torch.long)
+        with self.assertRaises(ValueError):
+            densify(ids, torch.zeros((3, 4)), end_frame_id=2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/video/deep/test_farl.py
+++ b/tests/video/deep/test_farl.py
@@ -210,6 +210,65 @@ class TestFarlWrapper(ModelTestCase):
         self.assertEqual(result["features"].shape[1], _FEATURE_DIM)
 
 
+class TestFarlTrackDensification(ModelTestCase):
+    """densify=True must put a real wrapper's sparse output on a gap-free grid."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = FarlWrapper(model_name=_DEFAULT_MODEL, device_id=None, pretrained=PRETRAINED)
+
+    @staticmethod
+    def _gapped_track(frame_ids: list[int]) -> Track:
+        """A track detected only on `frame_ids` — i.e. with holes, like a real one."""
+        frame = torch.randint(0, 255, (3, 400, 400), dtype=torch.uint8)
+        track = Track(track_id=0)
+        for fid in frame_ids:
+            track.add(
+                DetectionFromTorchTensor(
+                    frame_id=fid,
+                    source=frame,
+                    score=0.99,
+                    bb_xywh=torch.tensor([150, 150, 100, 100], dtype=torch.long),
+                    landmarks=torch.zeros(5, 2, dtype=torch.long),
+                )
+            )
+        return track
+
+    def test_sparse_is_still_the_default(self):
+        out = self.model.track_to_feature(self._gapped_track([0, 2, 7]))
+        self.assertEqual(out["features"].shape, (3, _FEATURE_DIM))
+        self.assertNotIn("mask", out)
+
+    def test_densify_fills_gaps_and_flags_them(self):
+        out = self.model.track_to_feature(
+            self._gapped_track([0, 2, 7]), densify=True, end_frame_id=8
+        )
+        self.assertEqual(out["features"].shape, (8, _FEATURE_DIM))
+        self.assertEqual(
+            out["mask"].tolist(), [True, False, True, False, False, False, False, True]
+        )
+        # Undetected frames hold the fill value, not a stale or garbage embedding.
+        self.assertTrue(torch.equal(out["features"][1], torch.zeros(_FEATURE_DIM)))
+
+    def test_densified_rows_match_the_sparse_features(self):
+        track = self._gapped_track([0, 2])
+        sparse = self.model.track_to_feature(track)
+        dense = self.model.track_to_feature(track, densify=True, end_frame_id=4)
+        torch.testing.assert_close(dense["features"][0], sparse["features"][0])
+        torch.testing.assert_close(dense["features"][2], sparse["features"][1])
+
+    def test_window_densification_does_not_materialise_the_whole_video(self):
+        out = self.model.track_to_feature(
+            self._gapped_track([0, 120, 200]),
+            densify=True,
+            start_frame_id=100,
+            end_frame_id=150,
+        )
+        self.assertEqual(out["features"].shape, (50, _FEATURE_DIM))
+        self.assertEqual(out["frame_ids"][0].item(), 100)
+        self.assertEqual(int(out["mask"].sum()), 1)  # only frame 120 falls in the window
+
+
 class TestFarlWeightAvailability(unittest.TestCase):
     def test_checkpoints_mirrored(self):
         # Checked against the mirror, not the FaRL GitHub release: GitHub rate-limits


### PR DESCRIPTION
`track_to_feature` returns one row per *detection*, so a track with gaps yields `(N, D)` with `N < num_frames`. That is the right default, but a temporal model fusing face, audio and text needs every stream on a common time axis.

## What
- **New:** `exordium.video.core.densify` — scatters sparse features onto `[start_frame_id, end_frame_id)`, fills gaps, returns a validity mask.
- **New:** `densify=True` on `VisualModelWrapper.track_to_feature`. Sparse stays the default; nothing existing changes.

## Design notes
- **The mask is load-bearing.** Zero-filled timesteps are *absences*, not observations of a zero-valued face. Without the mask, a model silently learns that "no face detected" is a meaningful feature value.
- **Contract matches MARLIN.** `frame_ids`/`features`/`mask` is exactly what `MarlinWrapper.track_to_feature` already emits, so densified frame-wise features and MARLIN's window-wise features are interchangeable downstream. MARLIN takes no `densify=` flag — its timestep is a 16-frame window, not a frame, so it is already dense by construction.
- **Windowing is O(window), not O(video)** — a 250-frame snippet out of a long track never materialises the full timeline.
- **Clipping over raising.** A long track legitimately overruns a short window, so out-of-range detections are dropped by default; `strict=True` raises.

## Tests
857 passing, 93% coverage (31 new). Verified densify produces correct shapes and masks across all 9 inheriting wrappers, including the three that do not define `feature_dim`.