### PR TITLE
ci: finish the GitHub Flow migration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,7 @@
-# Dependabot opens its PRs against dev, never main. main only accepts merges from dev
-# (enforced by the only-dev-into-main ruleset), so a PR based on main is blocked on
-# arrival and can never be merged -- which is what happened to #53.
 version: 2
 updates:
   - package-ecosystem: pip
     directory: "/"
-    target-branch: dev
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
@@ -30,7 +26,6 @@ updates:
 
   - package-ecosystem: github-actions
     directory: "/"
-    target-branch: dev
     schedule:
       interval: weekly
     open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main, dev]
+    branches: [main]
 
 jobs:
   test:


### PR DESCRIPTION
Two config changes intended for #60 that did not land in the merge.

- `dependabot.yml` — drop `target-branch: dev` from both ecosystems. Left as-is, dependabot would open PRs against a branch that is about to be deleted.
- `ci.yml` — run on pull requests into `main` only.

Merge this **before** deleting the `dev` branch.