### PR TITLE
feat(text): add mmBERT/EuroBERT wrappers and token-level pooling mode

### DIFF
--- a/exordium/text/base.py
+++ b/exordium/text/base.py
@@ -469,6 +469,115 @@ class TextModelWrapper(ABC):
         return torch.sum(last_hidden_state * mask, dim=1) / torch.clamp(mask.sum(dim=1), min=1e-9)
 
 
+class PooledTokenTextWrapper(TextModelWrapper):
+    r"""Encoder wrapper exposing both token-level and pooled outputs via ``pooling``.
+
+    A :class:`TextModelWrapper` whose ``preprocess → inference → __call__``
+    pipeline is parameterised by a ``pooling`` mode, so one wrapper serves both
+    an affective-computing fusion layer (which wants the token sequence) and a
+    sentence-similarity consumer (which wants one vector per input):
+
+    * ``pooling="none"`` — the raw token sequence ``last_hidden_state`` of shape
+      ``(B, T, H)`` (token-level; feed to a cross-modal sequence model such as
+      MulT/LinMulT alongside the ``attention_mask``).
+    * ``pooling="mean"`` (default) — the attention-masked mean-pooled sentence
+      embedding of shape ``(B, H)``.
+
+    A single ``str`` is encoded as a batch of one, so one sentence yields
+    ``(1, T, H)`` (token) or ``(1, H)`` (pooled); index ``[0]`` for the per-sample
+    ``(T, H)`` / ``(H,)`` views. ``H`` is read from the model config into
+    :attr:`hidden_size`, so it is never assumed.
+
+    Subclasses only need to call ``super().__init__(model_name, ...)`` with their
+    HuggingFace model id; the pooling API is inherited unchanged.
+
+    Attributes:
+        hidden_size: The backbone's hidden size ``H``, read from the model config.
+
+    """
+
+    def __init__(self, model_name: str, device_id: int = -1, pretrained: bool = True) -> None:
+        super().__init__(model_name, device_id, pretrained=pretrained)
+        self.hidden_size: int = self.model.config.hidden_size
+
+    def inference(
+        self,
+        inputs: dict[str, torch.Tensor],
+        pooling: str = "mean",
+    ) -> torch.Tensor:
+        """Run the encoder forward pass and return token-level or pooled features.
+
+        Args:
+            inputs: Tokenizer output dict on ``self.device``.
+            pooling: ``"none"`` returns the raw token sequence
+                ``last_hidden_state`` of shape ``(B, T, H)`` (token-level, for a
+                cross-modal sequence model). ``"mean"`` (default) returns the
+                attention-masked mean-pooled sentence embedding of shape
+                ``(B, H)``.
+
+        Returns:
+            Token embeddings ``(B, T, H)`` when ``pooling="none"``, or pooled
+            sentence embeddings ``(B, H)`` when ``pooling="mean"``.
+
+        Raises:
+            ValueError: If ``pooling`` is not ``"none"`` or ``"mean"``.
+
+        """
+        last_hidden = self.model(**inputs).last_hidden_state
+        if pooling == "none":
+            return last_hidden
+        if pooling == "mean":
+            return self._mean_pool(last_hidden, inputs["attention_mask"])
+        raise ValueError(f"Unknown pooling {pooling!r}; use 'none' or 'mean'.")
+
+    def __call__(
+        self,
+        text: str | list[str],
+        max_length: int | None = None,
+        padding: bool | str = True,
+        pooling: str = "mean",
+    ) -> torch.Tensor:
+        """Tokenize and encode text, returning a feature tensor.
+
+        Args:
+            text: Single string or list of strings.
+            max_length: Maximum sequence length. ``None`` uses tokenizer default.
+            padding: Padding strategy. Default: ``True`` (pad to longest).
+            pooling: Forwarded to :meth:`inference`. ``"mean"`` (default) returns
+                pooled ``(B, H)``; ``"none"`` returns token-level ``(B, T, H)``.
+
+        Returns:
+            Feature tensor on ``self.device``: ``(B, H)`` pooled by default, or
+            ``(B, T, H)`` token-level when ``pooling="none"``.
+
+        """
+        with torch.inference_mode():
+            return self.inference(self.preprocess(text, max_length, padding), pooling=pooling)
+
+    def predict(
+        self,
+        text: str | list[str],
+        max_length: int | None = None,
+        padding: bool | str = True,
+        pooling: str = "mean",
+    ) -> np.ndarray:
+        """Tokenize and encode text, returning a numpy feature array.
+
+        Args:
+            text: Single string or list of strings.
+            max_length: Maximum sequence length.
+            padding: Padding strategy.
+            pooling: Forwarded to :meth:`inference`. ``"mean"`` (default) returns
+                pooled ``(B, H)``; ``"none"`` returns token-level ``(B, T, H)``.
+
+        Returns:
+            Feature array: ``(B, H)`` pooled by default, or ``(B, T, H)``
+            token-level when ``pooling="none"``.
+
+        """
+        return self(text, max_length, padding, pooling=pooling).cpu().numpy()
+
+
 class SpeechToText(ABC):
     """Abstract base class for speech-to-text models.
 

--- a/exordium/text/eurobert.py
+++ b/exordium/text/eurobert.py
@@ -1,0 +1,53 @@
+"""EuroBERT multilingual text encoder wrapper (token-level or pooled).
+
+EuroBERT is a **EuroBERT-architecture** encoder (Llama-style: rotary embeddings,
+grouped-query attention) — not XLM-RoBERTa. It is kept in its own module so the
+naming stays architecture-honest; it shares the ``pooling`` API of
+:class:`~exordium.text.base.PooledTokenTextWrapper` with
+:class:`~exordium.text.xlm_roberta.XlmRobertaWrapper` and
+:class:`~exordium.text.mmbert.MmbertWrapper`.
+"""
+
+from exordium.text.base import PooledTokenTextWrapper
+
+
+class EurobertWrapper(PooledTokenTextWrapper):
+    r"""EuroBERT multilingual encoder — token-level ``(B, T, 1152)`` or pooled ``(B, 1152)``.
+
+    Loads ``EuroBERT/EuroBERT-610m``, a EuroBERT-architecture encoder for 15
+    European languages (**hidden 1152**, up to 8192 context, 2025) that is strong
+    on European-language, code, and math tasks, and returns either the token-level
+    sequence (``pooling="none"``, for a cross-modal sequence model such as
+    MulT/LinMulT) or a pooled sentence embedding (``pooling="mean"``, the default).
+    See :class:`~exordium.text.base.PooledTokenTextWrapper` for the full shape
+    contract and the ``pooling`` semantics.
+
+    Note the hidden size is **1152**, not 768 like the other multilingual wrappers;
+    read it from :attr:`hidden_size` rather than assuming a value. Use this wrapper
+    for European-language-heavy data; for broad multilingual coverage prefer
+    :class:`~exordium.text.mmbert.MmbertWrapper`, and for cross-lingually aligned
+    pooled embeddings prefer :class:`~exordium.text.xlm_roberta.XlmRobertaWrapper`.
+
+    `EuroBERT: Scaling Multilingual Encoders for European Languages, Boizard et al.
+    2025 <https://arxiv.org/abs/2503.05500>`_ ·
+    `card <https://huggingface.co/EuroBERT/EuroBERT-610m>`_
+
+    Args:
+        device_id: Device index. ``-1`` or ``None`` → CPU, ``0+`` → GPU/MPS.
+        pretrained: ``True`` (default) loads the real weights. ``False`` builds
+            the architecture with random weights — outputs are meaningless but the
+            shapes and call contract hold (used by the test suite to avoid downloads).
+
+    Attributes:
+        hidden_size: The backbone's hidden size ``H`` (1152), read from the config.
+
+    Example::
+
+        m = EurobertWrapper()
+        tokens = m("Ich bin sehr glücklich.", pooling="none")   # (1, T, 1152)
+        pooled = m("Ich bin sehr glücklich.")                   # (1, 1152)
+
+    """
+
+    def __init__(self, device_id: int = -1, pretrained: bool = True) -> None:
+        super().__init__("EuroBERT/EuroBERT-610m", device_id, pretrained=pretrained)

--- a/exordium/text/evaluation.py
+++ b/exordium/text/evaluation.py
@@ -241,10 +241,10 @@ def build_embedder(
     Args:
         model: One of ``"xlm-roberta"`` (default;
             :class:`~exordium.text.xlm_roberta.XlmRobertaWrapper`, a multilingual
-            sentence-transformer fine-tuned for semantic similarity — recommended),
-            ``"roberta"`` (:class:`~exordium.text.roberta.RobertaWrapper`, CLS
-            token), or ``"bert"`` (:class:`~exordium.text.bert.BertWrapper`, CLS
-            token).
+            sentence-transformer whose embeddings are cross-lingually aligned —
+            recommended for semantic similarity), ``"roberta"``
+            (:class:`~exordium.text.roberta.RobertaWrapper`, CLS token), or
+            ``"bert"`` (:class:`~exordium.text.bert.BertWrapper`, CLS token).
         device_id: Device index. ``-1`` or ``None`` → CPU, ``0+`` → GPU/MPS.
         pretrained: ``True`` (default) loads the real weights. ``False`` builds the
             architecture with random weights — embeddings are then meaningless, but the
@@ -259,8 +259,9 @@ def build_embedder(
     if name == "xlm-roberta":
         from exordium.text.xlm_roberta import XlmRobertaWrapper
 
-        wrapper = XlmRobertaWrapper(device_id=dev, pretrained=pretrained)
-        return lambda texts: wrapper(texts).detach().cpu().numpy()  # already (N, 768)
+        # mpnet is the cross-lingually aligned sentence-transformer (the wrapper default).
+        wrapper = XlmRobertaWrapper(backbone="mpnet", device_id=dev, pretrained=pretrained)
+        return lambda texts: wrapper(texts).detach().cpu().numpy()  # already pooled (N, H)
     if name == "roberta":
         from exordium.text.roberta import RobertaWrapper
 

--- a/exordium/text/mmbert.py
+++ b/exordium/text/mmbert.py
@@ -1,0 +1,52 @@
+"""mmBERT multilingual text encoder wrapper (token-level or pooled).
+
+mmBERT is a **ModernBERT-architecture** massively multilingual encoder — not
+XLM-RoBERTa. It is kept in its own module so the naming stays architecture-honest;
+it shares the ``pooling`` API of :class:`~exordium.text.base.PooledTokenTextWrapper`
+with :class:`~exordium.text.xlm_roberta.XlmRobertaWrapper` and
+:class:`~exordium.text.eurobert.EurobertWrapper`.
+"""
+
+from exordium.text.base import PooledTokenTextWrapper
+
+
+class MmbertWrapper(PooledTokenTextWrapper):
+    r"""mmBERT multilingual encoder — token-level ``(B, T, 768)`` or pooled ``(B, 768)``.
+
+    Loads ``jhu-clsp/mmBERT-base``, a ModernBERT-architecture massively
+    multilingual encoder (1800+ languages, hidden 768, up to 8192 context, 2025),
+    and returns either the token-level sequence (``pooling="none"``, for a
+    cross-modal sequence model such as MulT/LinMulT) or a pooled sentence
+    embedding (``pooling="mean"``, the default). See
+    :class:`~exordium.text.base.PooledTokenTextWrapper` for the full shape contract
+    and the ``pooling`` semantics.
+
+    mmBERT is a *pretrained* encoder, **not fine-tuned for semantic similarity**,
+    so its pooled embeddings are not cross-lingually aligned the way
+    :class:`~exordium.text.xlm_roberta.XlmRobertaWrapper`'s ``mpnet`` backbone is —
+    prefer that one for the pooled similarity path. mmBERT's strength here is the
+    modern, high-quality **token-level** representation.
+
+    `mmBERT: A Modern Multilingual Encoder with Annealed Language Learning, Marone
+    et al. 2025 <https://arxiv.org/abs/2509.06888>`_ ·
+    `card <https://huggingface.co/jhu-clsp/mmBERT-base>`_
+
+    Args:
+        device_id: Device index. ``-1`` or ``None`` → CPU, ``0+`` → GPU/MPS.
+        pretrained: ``True`` (default) loads the real weights. ``False`` builds
+            the architecture with random weights — outputs are meaningless but the
+            shapes and call contract hold (used by the test suite to avoid downloads).
+
+    Attributes:
+        hidden_size: The backbone's hidden size ``H`` (768), read from the config.
+
+    Example::
+
+        m = MmbertWrapper()
+        tokens = m("Ich bin sehr glücklich.", pooling="none")   # (1, T, 768)
+        pooled = m("Ich bin sehr glücklich.")                   # (1, 768)
+
+    """
+
+    def __init__(self, device_id: int = -1, pretrained: bool = True) -> None:
+        super().__init__("jhu-clsp/mmBERT-base", device_id, pretrained=pretrained)

--- a/exordium/text/xlm_roberta.py
+++ b/exordium/text/xlm_roberta.py
@@ -1,109 +1,81 @@
-"""XLM-RoBERTa multilingual text encoding wrapper."""
+"""XLM-RoBERTa multilingual text encoder wrapper (token-level or pooled).
 
-import numpy as np
-import torch
+Both backbones here are genuinely **XLM-RoBERTa architecture** encoders. For the
+newer non-XLM-RoBERTa multilingual encoders see
+:class:`~exordium.text.mmbert.MmbertWrapper` (ModernBERT) and
+:class:`~exordium.text.eurobert.EurobertWrapper` (EuroBERT); they share the same
+``pooling`` API but are separate classes so the naming stays architecture-honest.
+"""
 
-from exordium.text.base import TextModelWrapper
+from exordium.text.base import PooledTokenTextWrapper
+
+_BACKBONES: dict[str, str] = {
+    "mpnet": "sentence-transformers/paraphrase-multilingual-mpnet-base-v2",
+    "e5": "intfloat/multilingual-e5-base",
+}
+"""Named XLM-RoBERTa-architecture backbones. Keys are the short aliases accepted
+by :class:`XlmRobertaWrapper`; values are their HuggingFace Hub ids. A raw Hub id
+passed as ``backbone`` is used verbatim, so other XLM-RoBERTa checkpoints work too."""
 
 
-class XlmRobertaWrapper(TextModelWrapper):
-    """XLM-RoBERTa sentence-transformer wrapper. Hidden size: 768.
+class XlmRobertaWrapper(PooledTokenTextWrapper):
+    r"""XLM-RoBERTa multilingual encoder — token-level ``(B, T, H)`` or pooled ``(B, H)``.
 
-    This model is a sentence-transformer fine-tuned for semantic similarity, so
-    :meth:`inference` mean-pools the token embeddings internally and returns a
-    **pooled sentence embedding**: one ``(768,)`` vector per input, shape
-    ``(B, 768)``. There is *no* time axis — the pooled vector is not a length-1
-    sequence, and consumers should not treat ``(B, 768)`` as ``(B, T=1, 768)``.
+    Loads an **XLM-RoBERTa-architecture** multilingual encoder and returns either
+    the token-level sequence (``pooling="none"``, for a cross-modal sequence model
+    such as MulT/LinMulT) or a pooled sentence embedding (``pooling="mean"``, the
+    default, for sentence similarity). See
+    :class:`~exordium.text.base.PooledTokenTextWrapper` for the full shape contract
+    and the ``pooling`` semantics, and
+    :class:`~exordium.text.roberta.RobertaWrapper` for the English-only counterpart.
 
-    A time-series consumer that genuinely wants a length-1 sequence (e.g. a
-    LinMulT/LinT model with ``time_dim_reducer='gap'`` that expects ``(B, T, D)``)
-    can request the promoted rank explicitly via ``as_sequence=True``, which
-    returns ``(B, 1, 768)``. That unsqueeze is a consumer *choice* named here in
-    exordium rather than re-derived in every downstream repo; it adds no new
-    information over the pooled vector.
+    Both backbones have hidden size 768; :attr:`hidden_size` reports it from the
+    model config regardless.
+
+    Args:
+        backbone: Which XLM-RoBERTa encoder to load — a key of :data:`_BACKBONES`
+            or a raw HuggingFace Hub id. Options:
+
+            * ``"mpnet"`` (default) — XLM-RoBERTa sentence-transformer fine-tuned
+              for semantic similarity (50+ languages, hidden 768); its embeddings
+              are **cross-lingually aligned**, so it is the right choice for the
+              pooled similarity path.
+              `Sentence-BERT, Reimers & Gurevych 2019
+              <https://arxiv.org/abs/1908.10084>`_ · `card <https://huggingface.co/sentence-transformers/paraphrase-multilingual-mpnet-base-v2>`_
+            * ``"e5"`` — multilingual E5, initialized from XLM-RoBERTa and
+              contrastively retrained (100+ languages, hidden 768). Its *pooled*
+              mode expects ``"query: "`` / ``"passage: "`` prefixes on the input;
+              the token-level output is unaffected.
+              `Multilingual E5 Text Embeddings, Wang et al. 2024
+              <https://arxiv.org/abs/2402.05672>`_ · `card <https://huggingface.co/intfloat/multilingual-e5-base>`_
+
+        device_id: Device index. ``-1`` or ``None`` → CPU, ``0+`` → GPU/MPS.
+        pretrained: ``True`` (default) loads the real weights. ``False`` builds
+            the architecture with random weights — outputs are meaningless but the
+            shapes and call contract hold (used by the test suite to avoid downloads).
+
+    Attributes:
+        backbone: The ``backbone`` argument as given (alias or raw id).
+        hidden_size: The backbone's hidden size ``H`` (768), read from the config.
+
+    Example::
+
+        m = XlmRobertaWrapper()                                 # default: mpnet
+        tokens = m("Ich bin sehr glücklich.", pooling="none")   # (1, T, 768)
+        pooled = m("Ich bin sehr glücklich.")                   # (1, 768)
+        e5 = XlmRobertaWrapper(backbone="e5")                   # one-keyword switch
 
     """
 
-    def __init__(self, device_id: int = -1, pretrained: bool = True) -> None:
+    def __init__(
+        self,
+        backbone: str = "mpnet",
+        device_id: int = -1,
+        pretrained: bool = True,
+    ) -> None:
         super().__init__(
-            "sentence-transformers/paraphrase-multilingual-mpnet-base-v2",
+            _BACKBONES.get(backbone, backbone),
             device_id,
             pretrained=pretrained,
         )
-
-    def inference(
-        self,
-        inputs: dict[str, torch.Tensor],
-        as_sequence: bool = False,
-    ) -> torch.Tensor:
-        """Run XLM-RoBERTa forward pass with mean pooling.
-
-        Args:
-            inputs: Tokenizer output dict on ``self.device``.
-            as_sequence: When ``False`` (default), return the pooled sentence
-                embedding of shape ``(B, 768)`` — one ``(768,)`` vector per input,
-                with no time axis. When ``True``, unsqueeze a length-1 time axis
-                and return ``(B, 1, 768)``; this is a length-1 *sequence* view of
-                the same pooled vector, not additional information.
-
-        Returns:
-            Pooled sentence embeddings of shape ``(B, 768)``, or ``(B, 1, 768)``
-            when ``as_sequence`` is ``True``.
-
-        """
-        last_hidden = self.model(**inputs).last_hidden_state
-        pooled = self._mean_pool(last_hidden, inputs["attention_mask"])
-        if as_sequence:
-            return pooled.unsqueeze(1)
-        return pooled
-
-    def __call__(
-        self,
-        text: str | list[str],
-        max_length: int | None = None,
-        padding: bool | str = True,
-        as_sequence: bool = False,
-    ) -> torch.Tensor:
-        """Tokenize and encode text, returning a pooled sentence-embedding tensor.
-
-        Args:
-            text: Single string or list of strings.
-            max_length: Maximum sequence length. ``None`` uses tokenizer default.
-            padding: Padding strategy. Default: ``True`` (pad to longest).
-            as_sequence: Forwarded to :meth:`inference`. ``False`` returns
-                ``(B, 768)`` (pooled, no time axis); ``True`` returns
-                ``(B, 1, 768)`` (length-1 sequence view).
-
-        Returns:
-            Feature tensor on ``self.device``: ``(B, 768)`` by default, or
-            ``(B, 1, 768)`` when ``as_sequence`` is ``True``.
-
-        """
-        with torch.inference_mode():
-            return self.inference(
-                self.preprocess(text, max_length, padding), as_sequence=as_sequence
-            )
-
-    def predict(
-        self,
-        text: str | list[str],
-        max_length: int | None = None,
-        padding: bool | str = True,
-        as_sequence: bool = False,
-    ) -> np.ndarray:
-        """Tokenize and encode text, returning a pooled sentence-embedding array.
-
-        Args:
-            text: Single string or list of strings.
-            max_length: Maximum sequence length.
-            padding: Padding strategy.
-            as_sequence: Forwarded to :meth:`inference`. ``False`` returns
-                ``(B, 768)`` (pooled, no time axis); ``True`` returns
-                ``(B, 1, 768)`` (length-1 sequence view).
-
-        Returns:
-            Feature array: ``(B, 768)`` by default, or ``(B, 1, 768)`` when
-            ``as_sequence`` is ``True``.
-
-        """
-        return self(text, max_length, padding, as_sequence=as_sequence).cpu().numpy()
+        self.backbone = backbone

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -145,6 +145,66 @@ class ModelTestCase(unittest.TestCase):
         free_torch_memory()
 
 
+class PooledTokenWrapperContract:
+    """Shared real-model contract for the multilingual token/pooled wrappers.
+
+    Mix into a :class:`ModelTestCase` whose ``setUpClass`` sets ``cls.model`` to a
+    :class:`~exordium.text.base.PooledTokenTextWrapper` subclass. Asserts the
+    ``pooling`` API on the concrete class without duplicating the body across the
+    per-model test files (``test_xlm_roberta`` / ``test_mmbert`` / ``test_eurobert``)::
+
+        class TestMmbertWrapper(PooledTokenWrapperContract, ModelTestCase):
+            @classmethod
+            def setUpClass(cls):
+                from exordium.text.mmbert import MmbertWrapper
+                cls.model = MmbertWrapper(device_id=None, pretrained=PRETRAINED)
+    """
+
+    def test_call_returns_tensor(self):
+        """Calling the wrapper on a string returns a torch tensor."""
+        import torch
+
+        out = self.model("hello world")
+        self.assertIsInstance(out, torch.Tensor)
+
+    def test_default_output_is_pooled(self):
+        """The default output is a pooled ``(B, H)`` vector — rank 2."""
+        out = self.model("hello world")
+        self.assertEqual(out.ndim, 2)
+        self.assertEqual(out.shape[-1], self.model.hidden_size)
+
+    def test_pooling_none_is_token_level(self):
+        """``pooling='none'`` returns a token-level ``(B, T, H)`` sequence — rank 3."""
+        out = self.model("hello world", pooling="none")
+        self.assertEqual(out.ndim, 3)
+        self.assertEqual(out.shape[-1], self.model.hidden_size)
+
+    def test_hidden_size_matches_config(self):
+        """``hidden_size`` mirrors the backbone's ``config.hidden_size``."""
+        self.assertEqual(self.model.hidden_size, self.model.model.config.hidden_size)
+
+    def test_predict_returns_numpy(self):
+        """``predict`` returns a rank-2 numpy array by default (pooled)."""
+        import numpy as np
+
+        out = self.model.predict("hello world")
+        self.assertIsInstance(out, np.ndarray)
+        self.assertEqual(out.ndim, 2)
+
+    def test_batch_input_pooled(self):
+        """A batch of two pooled vectors is rank 2 with a leading batch of 2."""
+        out = self.model(["hello world", "a slightly longer second sentence"])
+        self.assertEqual(out.ndim, 2)
+        self.assertEqual(out.shape, (2, self.model.hidden_size))
+
+    def test_batch_input_token_level(self):
+        """A batch of two token sequences is rank 3; padded to a shared length T."""
+        out = self.model(["hello world", "a slightly longer second sentence"], pooling="none")
+        self.assertEqual(out.ndim, 3)
+        self.assertEqual(out.shape[0], 2)
+        self.assertEqual(out.shape[-1], self.model.hidden_size)
+
+
 _HF_PROBE_RETRY_PAUSES_S = (0.0, 1.0)
 """Pause before each retry after a transient failure, in seconds.
 

--- a/tests/text/test_eurobert.py
+++ b/tests/text/test_eurobert.py
@@ -1,0 +1,38 @@
+"""Tests for the EuroBERT multilingual text encoder wrapper.
+
+Exercises the shared token/pooled ``pooling`` contract against the real
+:class:`~exordium.text.eurobert.EurobertWrapper` (with random weights when
+``PRETRAINED`` is ``False``, so no checkpoint is downloaded), and confirms the
+backbone repo is reachable on the Hub. EuroBERT's hidden size is 1152, not 768;
+the contract reads it from the model config rather than assuming a value.
+"""
+
+import unittest
+
+from tests.fixtures import (
+    PRETRAINED,
+    ModelTestCase,
+    PooledTokenWrapperContract,
+    hf_repo_exists,
+)
+
+
+class TestEurobertWrapper(PooledTokenWrapperContract, ModelTestCase):
+    @classmethod
+    def setUpClass(cls):
+        from exordium.text.eurobert import EurobertWrapper
+
+        cls.model = EurobertWrapper(device_id=None, pretrained=PRETRAINED)
+
+    def test_hidden_size_is_1152(self):
+        """EuroBERT-610m has hidden size 1152 — the non-uniform case."""
+        self.assertEqual(self.model.hidden_size, 1152)
+
+
+class TestEurobertWeightAvailability(unittest.TestCase):
+    def test_eurobert_610m_repo(self):
+        self.assertTrue(hf_repo_exists("EuroBERT/EuroBERT-610m"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/text/test_mmbert.py
+++ b/tests/text/test_mmbert.py
@@ -1,0 +1,33 @@
+"""Tests for the mmBERT multilingual text encoder wrapper.
+
+Exercises the shared token/pooled ``pooling`` contract against the real
+:class:`~exordium.text.mmbert.MmbertWrapper` (with random weights when
+``PRETRAINED`` is ``False``, so no checkpoint is downloaded), and confirms the
+backbone repo is reachable on the Hub.
+"""
+
+import unittest
+
+from tests.fixtures import (
+    PRETRAINED,
+    ModelTestCase,
+    PooledTokenWrapperContract,
+    hf_repo_exists,
+)
+
+
+class TestMmbertWrapper(PooledTokenWrapperContract, ModelTestCase):
+    @classmethod
+    def setUpClass(cls):
+        from exordium.text.mmbert import MmbertWrapper
+
+        cls.model = MmbertWrapper(device_id=None, pretrained=PRETRAINED)
+
+
+class TestMmbertWeightAvailability(unittest.TestCase):
+    def test_mmbert_base_repo(self):
+        self.assertTrue(hf_repo_exists("jhu-clsp/mmBERT-base"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/text/test_wrappers.py
+++ b/tests/text/test_wrappers.py
@@ -11,6 +11,7 @@ from tests.fixtures import (
     PRETRAINED,
     TEST_WHISPER_MODEL,
     ModelTestCase,
+    PooledTokenWrapperContract,
     hf_repo_exists,
 )
 
@@ -86,20 +87,12 @@ class TestRobertaWrapper(ModelTestCase):
         self.assertIsInstance(out, np.ndarray)
 
 
-class TestXlmRobertaWrapper(ModelTestCase):
+class TestXlmRobertaWrapper(PooledTokenWrapperContract, ModelTestCase):
     @classmethod
     def setUpClass(cls):
         from exordium.text.xlm_roberta import XlmRobertaWrapper
 
         cls.model = XlmRobertaWrapper(device_id=None, pretrained=PRETRAINED)
-
-    def test_call_returns_tensor(self):
-        out = self.model("hello world")
-        self.assertIsInstance(out, torch.Tensor)
-
-    def test_output_is_sentence_level(self):
-        out = self.model("hello world")
-        self.assertEqual(out.ndim, 2)
 
 
 class TestWhisperWrapper(ModelTestCase):
@@ -143,6 +136,13 @@ class TestTextWeightAvailability(unittest.TestCase):
 
     def test_xlm_roberta_base_repo(self):
         self.assertTrue(hf_repo_exists("FacebookAI/xlm-roberta-base"))
+
+    def test_xlm_roberta_backbone_repos(self):
+        from exordium.text.xlm_roberta import _BACKBONES
+
+        for repo_id in _BACKBONES.values():
+            with self.subTest(repo_id=repo_id):
+                self.assertTrue(hf_repo_exists(repo_id))
 
 
 if __name__ == "__main__":

--- a/tests/text/test_xlm_roberta.py
+++ b/tests/text/test_xlm_roberta.py
@@ -1,10 +1,12 @@
-"""Shape-contract tests for XlmRobertaWrapper's pooled sentence embeddings.
+"""Shape-contract tests for the pooling API and the multilingual wrapper registries.
 
-These tests exercise the pooling + ``as_sequence`` promotion logic on a fake
-``last_hidden`` tensor and a stub model, so no checkpoint download or network
-access is needed. They lock in the contract that the default output is a pooled
-``(B, 768)`` vector with no time axis, and that ``as_sequence=True`` returns the
-same vector as a length-1 sequence ``(B, 1, 768)``.
+The pooling-mode tests exercise the ``pooling`` branch logic of
+:class:`~exordium.text.base.PooledTokenTextWrapper` on a fake ``last_hidden``
+tensor and a stub model, so no checkpoint download or network access is needed.
+They lock in the contract that ``pooling="mean"`` (default) returns a pooled
+``(B, H)`` vector and ``pooling="none"`` returns the raw token sequence
+``(B, T, H)``. ``H`` is parametrised over ``{768, 1152}`` so the differing-hidden
+case (EuroBERT) is covered without a download.
 """
 
 import inspect
@@ -12,7 +14,10 @@ import unittest
 
 import torch
 
-from exordium.text.xlm_roberta import XlmRobertaWrapper
+from exordium.text.base import PooledTokenTextWrapper, TextModelWrapper
+from exordium.text.eurobert import EurobertWrapper
+from exordium.text.mmbert import MmbertWrapper
+from exordium.text.xlm_roberta import _BACKBONES, XlmRobertaWrapper
 
 
 class _StubOutput:
@@ -22,22 +27,22 @@ class _StubOutput:
         self.last_hidden_state = last_hidden_state
 
 
-def _wrapper_with_fake_model(last_hidden: torch.Tensor) -> XlmRobertaWrapper:
-    """Build an XlmRobertaWrapper whose forward pass returns *last_hidden*.
+def _wrapper_with_fake_model(last_hidden: torch.Tensor) -> PooledTokenTextWrapper:
+    """Build a PooledTokenTextWrapper whose forward pass returns *last_hidden*.
 
     ``__new__`` skips ``__init__`` (which would download a checkpoint); the model
     and device are stubbed so :meth:`inference` runs offline. The stub model
     ignores its inputs and always returns *last_hidden*, which is all the pooling
-    and ``as_sequence`` shape logic under test needs.
+    shape logic under test needs.
     """
-    wrapper = XlmRobertaWrapper.__new__(XlmRobertaWrapper)
+    wrapper = PooledTokenTextWrapper.__new__(PooledTokenTextWrapper)
     wrapper.device = torch.device("cpu")
     wrapper.model = lambda **_: _StubOutput(last_hidden)
     return wrapper
 
 
-class TestXlmRobertaSequenceShape(unittest.TestCase):
-    """XlmRobertaWrapper.inference — pooled vs. length-1-sequence output shape."""
+class TestPoolingShape(unittest.TestCase):
+    """PooledTokenTextWrapper.inference — token-level vs. pooled output shape."""
 
     def _inputs(self, batch: int, seq_len: int, hidden: int = 768):
         last_hidden = torch.randn(batch, seq_len, hidden)
@@ -45,37 +50,50 @@ class TestXlmRobertaSequenceShape(unittest.TestCase):
         return last_hidden, {"attention_mask": attention_mask}
 
     def test_default_is_pooled_rank2(self):
-        """Default output is a pooled ``(B, 768)`` vector — rank 2, no time axis."""
-        last_hidden, inputs = self._inputs(batch=4, seq_len=7)
-        wrapper = _wrapper_with_fake_model(last_hidden)
+        """Default (``pooling='mean'``) output is pooled ``(B, H)`` — no time axis."""
+        for hidden in (768, 1152):
+            with self.subTest(hidden=hidden):
+                last_hidden, inputs = self._inputs(batch=4, seq_len=7, hidden=hidden)
+                wrapper = _wrapper_with_fake_model(last_hidden)
 
-        out = wrapper.inference(inputs)
+                out = wrapper.inference(inputs)
 
-        self.assertEqual(out.ndim, 2)
-        self.assertEqual(out.shape, (4, 768))
+                self.assertEqual(out.ndim, 2)
+                self.assertEqual(out.shape, (4, hidden))
 
-    def test_as_sequence_is_rank3_with_unit_time_axis(self):
-        """``as_sequence=True`` promotes to ``(B, 1, 768)`` — rank 3, T=1."""
-        last_hidden, inputs = self._inputs(batch=4, seq_len=7)
-        wrapper = _wrapper_with_fake_model(last_hidden)
-
-        out = wrapper.inference(inputs, as_sequence=True)
-
-        self.assertEqual(out.ndim, 3)
-        self.assertEqual(out.shape, (4, 1, 768))
-
-    def test_as_sequence_content_matches_pooled_squeezed(self):
-        """The ``(B, 1, 768)`` view squeezed on T equals the pooled ``(B, 768)``."""
+    def test_pooled_equals_mean_pool(self):
+        """``pooling='mean'`` equals the shared :meth:`TextModelWrapper._mean_pool`."""
         last_hidden, inputs = self._inputs(batch=3, seq_len=5)
         wrapper = _wrapper_with_fake_model(last_hidden)
 
-        pooled = wrapper.inference(inputs)
-        sequence = wrapper.inference(inputs, as_sequence=True)
+        out = wrapper.inference(inputs, pooling="mean")
+        expected = TextModelWrapper._mean_pool(last_hidden, inputs["attention_mask"])
 
-        self.assertTrue(torch.allclose(sequence.squeeze(1), pooled))
+        self.assertTrue(torch.allclose(out, expected))
 
-    def test_batch_of_one_default_stays_rank2(self):
-        """A batch of one keeps rank 2 ``(1, 768)`` — not collapsed to ``(768,)``."""
+    def test_none_is_rank3_token_sequence(self):
+        """``pooling='none'`` returns token-level ``(B, T, H)`` — rank 3, T preserved."""
+        for hidden in (768, 1152):
+            with self.subTest(hidden=hidden):
+                last_hidden, inputs = self._inputs(batch=4, seq_len=7, hidden=hidden)
+                wrapper = _wrapper_with_fake_model(last_hidden)
+
+                out = wrapper.inference(inputs, pooling="none")
+
+                self.assertEqual(out.ndim, 3)
+                self.assertEqual(out.shape, (4, 7, hidden))
+
+    def test_none_equals_raw_last_hidden(self):
+        """``pooling='none'`` returns the raw ``last_hidden_state`` untouched."""
+        last_hidden, inputs = self._inputs(batch=3, seq_len=5)
+        wrapper = _wrapper_with_fake_model(last_hidden)
+
+        out = wrapper.inference(inputs, pooling="none")
+
+        self.assertTrue(torch.equal(out, last_hidden))
+
+    def test_batch_of_one_pooled_stays_rank2(self):
+        """A batch of one keeps rank 2 ``(1, H)`` — not collapsed to ``(H,)``."""
         last_hidden, inputs = self._inputs(batch=1, seq_len=6)
         wrapper = _wrapper_with_fake_model(last_hidden)
 
@@ -83,11 +101,76 @@ class TestXlmRobertaSequenceShape(unittest.TestCase):
 
         self.assertEqual(out.shape, (1, 768))
 
+    def test_batch_of_one_token_stays_rank3(self):
+        """A batch of one keeps rank 3 ``(1, T, H)`` for the token-level mode."""
+        last_hidden, inputs = self._inputs(batch=1, seq_len=6)
+        wrapper = _wrapper_with_fake_model(last_hidden)
+
+        out = wrapper.inference(inputs, pooling="none")
+
+        self.assertEqual(out.shape, (1, 6, 768))
+
+    def test_per_sample_views(self):
+        """``[0]`` drops the batch axis: token → ``(T, H)``, pooled → ``(H,)``."""
+        last_hidden, inputs = self._inputs(batch=2, seq_len=5)
+        wrapper = _wrapper_with_fake_model(last_hidden)
+
+        token = wrapper.inference(inputs, pooling="none")
+        pooled = wrapper.inference(inputs, pooling="mean")
+
+        self.assertEqual(token[0].shape, (5, 768))
+        self.assertEqual(pooled[0].shape, (768,))
+
+    def test_invalid_pooling_raises(self):
+        """An unknown ``pooling`` value raises ``ValueError``."""
+        last_hidden, inputs = self._inputs(batch=2, seq_len=4)
+        wrapper = _wrapper_with_fake_model(last_hidden)
+
+        with self.assertRaises(ValueError):
+            wrapper.inference(inputs, pooling="cls")
+
     def test_signature_defaults_to_pooled(self):
-        """``as_sequence`` defaults to False, so existing callers are unaffected."""
-        sig = inspect.signature(XlmRobertaWrapper.inference)
-        self.assertIn("as_sequence", sig.parameters)
-        self.assertEqual(sig.parameters["as_sequence"].default, False)
+        """``pooling`` defaults to 'mean', so existing callers get pooled output."""
+        sig = inspect.signature(PooledTokenTextWrapper.inference)
+        self.assertIn("pooling", sig.parameters)
+        self.assertEqual(sig.parameters["pooling"].default, "mean")
+
+
+class TestXlmRobertaBackboneRegistry(unittest.TestCase):
+    """XlmRobertaWrapper carries only genuine XLM-RoBERTa backbones."""
+
+    def test_only_xlm_roberta_backbones_registered(self):
+        """Only the two XLM-RoBERTa-architecture aliases are registered here."""
+        self.assertEqual(set(_BACKBONES), {"mpnet", "e5"})
+
+    def test_default_backbone_is_mpnet(self):
+        """The constructor default is the aligned mpnet backbone."""
+        sig = inspect.signature(XlmRobertaWrapper.__init__)
+        self.assertEqual(sig.parameters["backbone"].default, "mpnet")
+
+    def test_aliases_map_to_expected_repo_ids(self):
+        """Each alias resolves to its expected XLM-RoBERTa HuggingFace repo id."""
+        self.assertEqual(
+            _BACKBONES["mpnet"],
+            "sentence-transformers/paraphrase-multilingual-mpnet-base-v2",
+        )
+        self.assertEqual(_BACKBONES["e5"], "intfloat/multilingual-e5-base")
+
+
+class TestStandaloneWrapperClasses(unittest.TestCase):
+    """mmBERT and EuroBERT are standalone classes, not XlmRobertaWrapper backbones."""
+
+    def test_all_share_the_pooling_base(self):
+        """Every multilingual wrapper inherits the shared pooling API."""
+        for cls in (XlmRobertaWrapper, MmbertWrapper, EurobertWrapper):
+            with self.subTest(cls=cls.__name__):
+                self.assertTrue(issubclass(cls, PooledTokenTextWrapper))
+
+    def test_non_xlm_roberta_models_are_not_in_registry(self):
+        """mmBERT/EuroBERT repo ids do not leak into the XLM-RoBERTa registry."""
+        ids = set(_BACKBONES.values())
+        self.assertNotIn("jhu-clsp/mmBERT-base", ids)
+        self.assertNotIn("EuroBERT/EuroBERT-610m", ids)
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -3340,11 +3340,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "81.0.0"
+version = "83.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0d/1c/73e719955c59b8e424d015ab450f51c0af856ae46ea2da83eba51cc88de1/setuptools-81.0.0.tar.gz", hash = "sha256:487b53915f52501f0a79ccfd0c02c165ffe06631443a886740b91af4b7a5845a", size = 1198299, upload-time = "2026-02-06T21:10:39.601Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/e3/c164c88b2e5ce7b24d667b9bd83589cf4f3520d97cad01534cd3c4f55fdb/setuptools-81.0.0-py3-none-any.whl", hash = "sha256:fdd925d5c5d9f62e4b74b30d6dd7828ce236fd6ed998a08d81de62ce5a6310d6", size = 1062021, upload-time = "2026-02-06T21:10:37.175Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds multilingual token-level (B,T,H) text features for MulT/LinMulT fusion alongside pooled (B,H). New standalone MmbertWrapper and EurobertWrapper; shared PooledTokenTextWrapper base; XlmRobertaWrapper kept to genuine XLM-RoBERTa backbones (mpnet default, e5). Semantic-similarity path pinned to mpnet, so unchanged. 100% coverage on new wrappers; setuptools vuln bumped.